### PR TITLE
Decimal: improve library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Decimal: use num_bigint crate to increase increase range of allowed values and prevent avoidable overflow; increase test coverage ([#55])
+
+[#55]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/55
+
 ## [0.3.1] - 2023-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,10 @@ dependencies = [
 [[package]]
 name = "decimal"
 version = "0.3.1"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+]
 
 [[package]]
 name = "derive_arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -118,6 +118,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -218,6 +224,7 @@ version = "0.3.1"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "wee_alloc",
 ]
 
 [[package]]
@@ -309,7 +316,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -712,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -1073,7 +1080,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -1137,6 +1144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92a94fbf4c521b038f41382df2056cf47099d3b7a0faa5a6e46f7771fd7c84a6"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/packages/decimal/Cargo.toml
+++ b/packages/decimal/Cargo.toml
@@ -9,3 +9,5 @@ license = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-bigint = { version = "0.4", default-features = false }
+num-traits = { version = "0.2", default-features = false }

--- a/packages/decimal/Cargo.toml
+++ b/packages/decimal/Cargo.toml
@@ -11,3 +11,4 @@ license = { workspace = true }
 [dependencies]
 num-bigint = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+wee_alloc = "0.4.5"

--- a/packages/decimal/src/lib.rs
+++ b/packages/decimal/src/lib.rs
@@ -11,6 +11,12 @@ use core::{
 use num_bigint::ToBigInt;
 use num_traits::ToPrimitive;
 
+extern crate alloc;
+extern crate wee_alloc;
+
+#[global_allocator]
+static ALLOCATOR: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
 #[derive(Debug)]
 enum Error {
     Overflow,

--- a/packages/decimal/src/lib.rs
+++ b/packages/decimal/src/lib.rs
@@ -597,4 +597,25 @@ mod tests {
     fn decimal_div_by_zero_panics() {
         let _value = Decimal::one() / Decimal::zero();
     }
+
+    #[test]
+    fn decimal_i128_division() {
+        // a/b
+        let left = Decimal::percent(150); // 1.5
+        let right = 3i128;
+        assert_eq!(left / right, Decimal::percent(50));
+
+        // 0/a
+        let left = Decimal::zero();
+        let right = 300i128;
+        assert_eq!(left / right, Decimal::zero());
+    }
+
+    #[test]
+    #[should_panic(expected = "attempt to divide by zero")]
+    fn decimal_uint128_divide_by_zero() {
+        let left = Decimal::percent(150); // 1.5
+        let right = 0i128;
+        let _result = left / right;
+    }
 }


### PR DESCRIPTION
Use [num-bigint](https://crates.io/crates/num-bigint) for better precision in certain operations.
Increase test coverage.