### PR TITLE
Stake: Implement rewards that increases every time user withdraws

### DIFF
--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -270,7 +270,7 @@ impl StakingTrait for Staking {
             // including only the reward config amount that is eligible for distribution.
             // This is the amount we will distribute to all mem
             let amount =
-                undistributed_rewards - withdrawable - curve.value(env.ledger().timestamp());
+                dbg!(undistributed_rewards - withdrawable - curve.value(env.ledger().timestamp()));
 
             if amount == 0 {
                 continue;
@@ -278,16 +278,18 @@ impl StakingTrait for Staking {
 
             let leftover: u128 = distribution.shares_leftover.into();
             let points = (amount << SHARES_SHIFT) + leftover;
-            let points_per_share = points / total_rewards_power;
+            let points_per_share = dbg!(dbg!(points) / dbg!(total_rewards_power));
             distribution.shares_leftover = (points % total_rewards_power) as u64;
 
             // Everything goes back to 128-bits/16-bytes
             // Full amount is added here to total withdrawable, as it should not be considered on its own
             // on future distributions - even if because of calculation offsets it is not fully
             // distributed, the error is handled by leftover.
+            dbg!(distribution.shares_per_point);
             distribution.shares_per_point += points_per_share;
             distribution.distributed_total += amount;
             distribution.withdrawable_total += amount;
+            dbg!(distribution.shares_per_point);
 
             save_distribution(&env, &distribution_address, &distribution);
 
@@ -314,7 +316,7 @@ impl StakingTrait for Staking {
             // calculate current reward amount given the distribution and subtracting withdraw
             // adjustments
             let reward_amount =
-                withdrawable_rewards(&env, &sender, &distribution, &withdraw_adjustment)?;
+                dbg!(withdrawable_rewards(&env, &sender, &distribution, &withdraw_adjustment)?);
 
             if reward_amount == 0 {
                 continue;

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -377,7 +377,6 @@ impl StakingTrait for Staking {
                 .publish(("withdraw_rewards", "reward_amount"), reward_amount as i128);
         }
 
-        save_withdraw_adjustments(&env, &sender, &updated_withdraw_adjustments);
         update_stakes_rewards(&env, &sender)?;
 
         Ok(())

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -463,8 +463,11 @@ impl StakingTrait for Staking {
     }
 
     fn query_staked(env: Env, address: Address) -> Result<StakedResponse, ContractError> {
+        let bonding_info = get_stakes(&env, &address)?;
         Ok(StakedResponse {
-            stakes: get_stakes(&env, &address)?.stakes,
+            stakes: bonding_info.stakes,
+            current_rewards_bps: bonding_info.current_rewards_bps,
+            total_stake: bonding_info.total_stake,
         })
     }
 

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -15,7 +15,7 @@ use crate::{
         get_config, get_stakes, save_config, save_stakes, update_stakes_rewards,
         utils::{
             self, add_distribution, get_admin, get_distributions, get_total_staked_counter,
-            reset_stake_increases,
+            reset_stake_increase_counter,
         },
         Config, Stake,
     },
@@ -168,6 +168,7 @@ impl StakingTrait for Staking {
             stake_timestamp: ledger.timestamp(),
         };
         stakes.total_stake += tokens as u128;
+        stakes.virtual_stake += tokens as u128;
         // TODO: Discuss: Add implementation to add stake if another is present in +-24h timestamp to avoid
         // creating multiple stakes the same day
 
@@ -292,7 +293,7 @@ impl StakingTrait for Staking {
             // stake increase caused by rewards withdrawals
             let stake_increase = Decimal::one()
                 - Decimal::bps(config.bonus_per_day_bps)
-                    * Decimal::from_ratio(utils::get_stake_increases(&env), 1);
+                    * Decimal::from_ratio(utils::get_stake_increase_counter(&env), 1);
 
             let points = (points as i128 * stake_increase) as u128;
             let points_per_share = points / total_rewards_power;
@@ -317,7 +318,7 @@ impl StakingTrait for Staking {
         }
 
         // reset counter of total stake increase due to bonus rewards added during withdrawals
-        reset_stake_increases(&env);
+        reset_stake_increase_counter(&env);
 
         Ok(())
     }

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -59,6 +59,8 @@ pub struct Distribution {
     pub withdrawable_total: u128,
     /// The manager of this distribution
     pub manager: Address,
+    /// The total amount of distribution points; required for proper reward calculation
+    pub total_points: u128,
 }
 
 pub fn save_distribution(env: &Env, asset: &Address, distribution: &Distribution) {

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -59,10 +59,6 @@ pub struct Distribution {
     pub withdrawable_total: u128,
     /// The manager of this distribution
     pub manager: Address,
-    /// Max bonus for staking after 60 days
-    pub max_bonus_bps: u64,
-    /// Bonus per staking day
-    pub bonus_per_day_bps: u64,
 }
 
 pub fn save_distribution(env: &Env, asset: &Address, distribution: &Distribution) {

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -167,7 +167,7 @@ pub fn withdrawable_rewards(
     let ppw = distribution.shares_per_point;
 
     let points = get_stakes(env, owner)?.total_stake;
-    let points = (ppw * points) as i128;
+    let points = dbg!((ppw * points) as i128);
 
     let correction = adjustment.shares_correction;
     let points = points + correction;

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -167,7 +167,7 @@ pub fn withdrawable_rewards(
     let ppw = distribution.shares_per_point;
 
     let points = get_stakes(env, owner)?.total_stake;
-    let points = dbg!((ppw * points) as i128);
+    let points = (ppw * points) as i128;
 
     let correction = adjustment.shares_correction;
     let points = points + correction;

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -166,7 +166,7 @@ pub fn withdrawable_rewards(
 ) -> Result<u128, ContractError> {
     let ppw = distribution.shares_per_point;
 
-    let points = get_stakes(env, owner)?.total_stake;
+    let points = get_stakes(env, owner)?.virtual_stake;
     let points = (ppw * points) as i128;
 
     let correction = adjustment.shares_correction;

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 mod contract;
 mod distribution;
 mod error;

--- a/contracts/stake/src/msg.rs
+++ b/contracts/stake/src/msg.rs
@@ -15,6 +15,8 @@ pub struct ConfigResponse {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StakedResponse {
     pub stakes: Vec<Stake>,
+    pub current_rewards_bps: i64,
+    pub total_stake: u128
 }
 
 #[contracttype]

--- a/contracts/stake/src/msg.rs
+++ b/contracts/stake/src/msg.rs
@@ -16,7 +16,7 @@ pub struct ConfigResponse {
 pub struct StakedResponse {
     pub stakes: Vec<Stake>,
     pub current_rewards_bps: i64,
-    pub total_stake: u128
+    pub total_stake: u128,
 }
 
 #[contracttype]

--- a/contracts/stake/src/storage.rs
+++ b/contracts/stake/src/storage.rs
@@ -1,6 +1,9 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 use crate::error::ContractError;
+use decimal::Decimal;
+
+const DAY_IN_SECONDS: u64 = 60 * 60 * 24;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -9,6 +12,10 @@ pub struct Config {
     pub min_bond: i128,
     pub max_distributions: u32,
     pub min_reward: i128,
+    /// Max bonus for staking after 60 days
+    pub max_bonus_bps: i64,
+    /// Bonus per staking day
+    pub bonus_per_day_bps: i64,
 }
 const CONFIG: Symbol = symbol_short!("CONFIG");
 
@@ -37,15 +44,14 @@ pub struct Stake {
 pub struct BondingInfo {
     /// Vec of stakes sorted by stake timestamp
     pub stakes: Vec<Stake>,
-    /// The rewards debt is a mechanism to determine how much a user has already been credited in terms of staking rewards.
-    /// Whenever a user deposits or withdraws staked tokens to the pool, the rewards for the user is updated based on the
-    /// accumulated rewards per share, and the difference is stored as reward debt. When claiming rewards, this reward debt
-    /// is used to determine how much rewards a user can actually claim.
-    pub reward_debt: u128,
     /// Last time when user has claimed rewards
+    /// User can withdraw rewards as often as they want, but this parameter resets
+    /// only after 24h when reward percentage is bumped
     pub last_reward_time: u64,
-    /// Total amount of staked tokens
+    /// Total amount of staked tokens plus rewards
     pub total_stake: u128,
+    /// Current rewards percentage in bps
+    pub current_rewards_bps: i64,
 }
 
 pub fn get_stakes(env: &Env, key: &Address) -> Result<BondingInfo, ContractError> {
@@ -53,15 +59,43 @@ pub fn get_stakes(env: &Env, key: &Address) -> Result<BondingInfo, ContractError
         Some(stake) => stake,
         None => Ok(BondingInfo {
             stakes: Vec::new(env),
-            reward_debt: 0u128,
             last_reward_time: 0u64,
             total_stake: 0u128,
+            current_rewards_bps: 0i64,
         }),
     }
 }
 
 pub fn save_stakes(env: &Env, key: &Address, bonding_info: &BondingInfo) {
     env.storage().persistent().set(key, bonding_info);
+}
+
+pub fn update_stakes_rewards(env: &Env, key: &Address) -> Result<(), ContractError> {
+    let mut bonding_info = get_stakes(env, key)?;
+    let current_time = env.ledger().timestamp();
+
+    // if last_reward_time is 0, it means that user has never claimed rewards
+    // otherwise check if rewards were claimed more than 24h ago
+    // (-1 second is to allow rewards to be claimed exactly after 24h)
+    if bonding_info.last_reward_time == 0
+        || bonding_info.last_reward_time + DAY_IN_SECONDS - 1 < current_time
+    {
+        bonding_info.last_reward_time = current_time;
+        let config = get_config(env)?;
+        // if rewards are already at maximum, do nothing
+        if bonding_info.current_rewards_bps >= config.max_bonus_bps {
+            return Ok(());
+        }
+        // update rewards percentage (in bps)
+        bonding_info.current_rewards_bps += config.bonus_per_day_bps;
+        // calculate bonus staking points
+        let reward_stake_points =
+            bonding_info.total_stake as i128 * Decimal::bps(bonding_info.current_rewards_bps);
+        bonding_info.total_stake += reward_stake_points as u128;
+
+        save_stakes(env, key, &bonding_info);
+    }
+    Ok(())
 }
 
 pub mod utils {

--- a/contracts/stake/src/storage.rs
+++ b/contracts/stake/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
-use crate::error::ContractError;
+use crate::{distribution::{get_distribution, save_distribution, SHARES_SHIFT}, error::ContractError};
 use decimal::Decimal;
 
 const DAY_IN_SECONDS: u64 = 60 * 60 * 24;
@@ -94,12 +94,36 @@ pub fn update_stakes_rewards(env: &Env, key: &Address) -> Result<(), ContractErr
         // calculate bonus staking points
         let reward_stake_points =
             bonding_info.total_stake as i128 * Decimal::bps(bonding_info.current_rewards_bps);
+        let user_original_virtual_stake = bonding_info.virtual_stake;
         bonding_info.virtual_stake = bonding_info.total_stake + reward_stake_points as u128;
         // Important - also increase total staked counter, otherwise there would be a gap
         utils::increase_total_virtual_staked(env, &reward_stake_points)?;
         utils::increment_stake_increase_counter(env);
 
         save_stakes(env, key, &bonding_info);
+        let total_rewards_power = dbg!(utils::get_total_virtual_staked_counter(&env)? as u128);
+        for distribution_address in utils::get_distributions(&env) {
+            let mut distribution = get_distribution(&env, &distribution_address)?;
+
+            let user_original_share = Decimal::from_ratio(user_original_virtual_stake as i128, total_rewards_power as i128);
+            let user_original_points = (distribution.total_points - reward_stake_points as u128 ) as i128 * user_original_share;
+
+            let user_new_share = Decimal::from_ratio(bonding_info.virtual_stake as i128, utils::get_total_virtual_staked_counter(env)?);
+            let user_new_points = distribution.total_points as i128 * user_new_share;
+
+            let total_points = distribution.total_points - user_original_points as u128 + user_new_points as u128;
+            let points_per_share = total_points / total_rewards_power;
+            distribution.shares_per_point = points_per_share;
+            dbg!(distribution.total_points);
+            dbg!(distribution.shares_per_point);
+
+            // Update the leftover points
+            distribution.shares_leftover = (distribution.total_points % total_rewards_power) as u64;
+
+            dbg!(points_per_share);
+            // Save the updated distribution back to storage
+            save_distribution(env, &distribution_address, &distribution);
+        }
     }
     Ok(())
 }

--- a/contracts/stake/src/storage.rs
+++ b/contracts/stake/src/storage.rs
@@ -94,6 +94,7 @@ pub fn update_stakes_rewards(env: &Env, key: &Address) -> Result<(), ContractErr
         bonding_info.total_stake += reward_stake_points as u128;
         // Important - also increase total staked counter, otherwise there would be a gap
         utils::increase_total_staked(env, &reward_stake_points)?;
+        utils::increase_stake_increases(env);
 
         save_stakes(env, key, &bonding_info);
     }
@@ -111,6 +112,7 @@ pub mod utils {
         Admin = 0,
         TotalStaked = 1,
         Distributions = 2,
+        StakeIncreases = 3,
     }
 
     impl TryFromVal<Env, DataKey> for Val {
@@ -179,5 +181,25 @@ pub mod utils {
             .persistent()
             .get(&DataKey::Distributions)
             .unwrap_or_else(|| soroban_sdk::vec![e])
+    }
+
+    pub fn increase_stake_increases(e: &Env) {
+        let count = get_stake_increases(e);
+        e.storage()
+            .persistent()
+            .set(&DataKey::StakeIncreases, &(count + 1i128));
+    }
+
+    pub fn reset_stake_increases(e: &Env) {
+        e.storage()
+            .persistent()
+            .set(&DataKey::StakeIncreases, &0i128);
+    }
+
+    pub fn get_stake_increases(env: &Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::StakeIncreases)
+            .unwrap_or(0i128)
     }
 }

--- a/contracts/stake/src/storage.rs
+++ b/contracts/stake/src/storage.rs
@@ -92,6 +92,8 @@ pub fn update_stakes_rewards(env: &Env, key: &Address) -> Result<(), ContractErr
         let reward_stake_points =
             bonding_info.total_stake as i128 * Decimal::bps(bonding_info.current_rewards_bps);
         bonding_info.total_stake += reward_stake_points as u128;
+        // Important - also increase total staked counter, otherwise there would be a gap
+        utils::increase_total_staked(env, &reward_stake_points)?;
 
         save_stakes(env, key, &bonding_info);
     }

--- a/contracts/stake/src/tests.rs
+++ b/contracts/stake/src/tests.rs
@@ -1,3 +1,4 @@
 mod bond;
 mod distribution;
+mod rewards;
 mod setup;

--- a/contracts/stake/src/tests/bond.rs
+++ b/contracts/stake/src/tests/bond.rs
@@ -31,8 +31,8 @@ fn initialize_staking_contract() {
                 min_bond: 1_000i128,
                 max_distributions: 7u32,
                 min_reward: 1_000i128,
-                bonus_per_day_bps: 500i64,
-                max_bonus_bps: 30_000i64,
+                bonus_per_day_bps: 50i64,
+                max_bonus_bps: 3_000i64,
             }
         }
     );

--- a/contracts/stake/src/tests/bond.rs
+++ b/contracts/stake/src/tests/bond.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[test]
-fn initializa_staking_contract() {
+fn initialize_staking_contract() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -30,7 +30,9 @@ fn initializa_staking_contract() {
                 lp_token: lp_token.address,
                 min_bond: 1_000i128,
                 max_distributions: 7u32,
-                min_reward: 1_000i128
+                min_reward: 1_000i128,
+                bonus_per_day_bps: 500i64,
+                max_bonus_bps: 30_000i64,
             }
         }
     );

--- a/contracts/stake/src/tests/distribution.rs
+++ b/contracts/stake/src/tests/distribution.rs
@@ -191,7 +191,7 @@ fn two_distributions() {
 
     staking.withdraw_rewards(&user);
     assert_eq!(reward_token.balance(&user), reward_amount as i128);
-    assert_eq!(reward_token_2.balance(&user), (reward_amount * 2) as i128);
+    assert_eq!(reward_token_2.balance(&user), (reward_amount * 3) as i128);
 }
 
 #[test]

--- a/contracts/stake/src/tests/distribution.rs
+++ b/contracts/stake/src/tests/distribution.rs
@@ -179,19 +179,22 @@ fn two_distributions() {
                 &env,
                 WithdrawableReward {
                     reward_address: reward_token.address.clone(),
-                    reward_amount: reward_amount / 2
+                    reward_amount: (reward_amount / 2) - 1 // FIXME: rounding issue
                 },
                 WithdrawableReward {
                     reward_address: reward_token_2.address.clone(),
-                    reward_amount
+                    reward_amount: reward_amount - 1 // FIXME: rounding issue
                 }
             ]
         }
     );
 
     staking.withdraw_rewards(&user);
-    assert_eq!(reward_token.balance(&user), reward_amount as i128);
-    assert_eq!(reward_token_2.balance(&user), (reward_amount * 3) as i128);
+    assert_eq!(reward_token.balance(&user), (reward_amount - 1) as i128);
+    assert_eq!(
+        reward_token_2.balance(&user),
+        (reward_amount * 2 - 1) as i128
+    );
 }
 
 #[test]

--- a/contracts/stake/src/tests/distribution.rs
+++ b/contracts/stake/src/tests/distribution.rs
@@ -114,13 +114,6 @@ fn two_distributions() {
         &reward_token.address,
         &(reward_amount as i128),
     );
-    staking.fund_distribution(
-        &admin,
-        &2_000,
-        &reward_duration,
-        &reward_token_2.address,
-        &((reward_amount * 2) as i128),
-    );
 
     // distribute rewards during half time
     env.ledger().with_mut(|li| {
@@ -138,14 +131,13 @@ fn two_distributions() {
                 },
                 WithdrawableReward {
                     reward_address: reward_token_2.address.clone(),
-                    reward_amount
-                }
+                    reward_amount: 0
+                },
             ]
         }
     );
     staking.withdraw_rewards(&user);
     assert_eq!(reward_token.balance(&user), (reward_amount / 2) as i128);
-    assert_eq!(reward_token_2.balance(&user), reward_amount as i128);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 2_600;
@@ -160,15 +152,6 @@ fn two_distributions() {
         staking.query_distributed_rewards(&reward_token.address),
         reward_amount
     );
-    // second reward token
-    assert_eq!(
-        staking.query_undistributed_rewards(&reward_token_2.address),
-        0
-    );
-    assert_eq!(
-        staking.query_distributed_rewards(&reward_token_2.address),
-        reward_amount * 2
-    );
 
     // since half of rewards were already distributed, after full distirubtion
     // round another half is ready
@@ -181,10 +164,6 @@ fn two_distributions() {
                     reward_address: reward_token.address.clone(),
                     reward_amount: reward_amount / 2
                 },
-                WithdrawableReward {
-                    reward_address: reward_token_2.address.clone(),
-                    reward_amount
-                }
             ]
         }
     );

--- a/contracts/stake/src/tests/distribution.rs
+++ b/contracts/stake/src/tests/distribution.rs
@@ -114,6 +114,13 @@ fn two_distributions() {
         &reward_token.address,
         &(reward_amount as i128),
     );
+    staking.fund_distribution(
+        &admin,
+        &2_000,
+        &reward_duration,
+        &reward_token_2.address,
+        &((reward_amount * 2) as i128),
+    );
 
     // distribute rewards during half time
     env.ledger().with_mut(|li| {
@@ -131,13 +138,14 @@ fn two_distributions() {
                 },
                 WithdrawableReward {
                     reward_address: reward_token_2.address.clone(),
-                    reward_amount: 0
+                    reward_amount
                 },
             ]
         }
     );
     staking.withdraw_rewards(&user);
     assert_eq!(reward_token.balance(&user), (reward_amount / 2) as i128);
+    assert_eq!(reward_token_2.balance(&user), reward_amount as i128);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 2_600;
@@ -152,6 +160,15 @@ fn two_distributions() {
         staking.query_distributed_rewards(&reward_token.address),
         reward_amount
     );
+    // second reward token
+    assert_eq!(
+        staking.query_undistributed_rewards(&reward_token_2.address),
+        0
+    );
+    assert_eq!(
+        staking.query_distributed_rewards(&reward_token_2.address),
+        reward_amount * 2
+    );
 
     // since half of rewards were already distributed, after full distirubtion
     // round another half is ready
@@ -164,6 +181,10 @@ fn two_distributions() {
                     reward_address: reward_token.address.clone(),
                     reward_amount: reward_amount / 2
                 },
+                WithdrawableReward {
+                    reward_address: reward_token_2.address.clone(),
+                    reward_amount
+                }
             ]
         }
     );

--- a/contracts/stake/src/tests/rewards.rs
+++ b/contracts/stake/src/tests/rewards.rs
@@ -73,7 +73,10 @@ fn four_users_same_stakes_different_multipliers() {
     );
     staking.withdraw_rewards(&user);
     assert_eq!(reward_token.balance(&user), 62_500);
-    assert_eq!(staking.query_distributed_rewards(&reward_token.address), 250_000);
+    assert_eq!(
+        staking.query_distributed_rewards(&reward_token.address),
+        250_000
+    );
     env.ledger().with_mut(|li| {
         li.timestamp = DAY_IN_SECONDS + 1;
     });

--- a/contracts/stake/src/tests/rewards.rs
+++ b/contracts/stake/src/tests/rewards.rs
@@ -1,0 +1,196 @@
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env,
+};
+
+use super::setup::{deploy_staking_contract, deploy_token_contract};
+
+use crate::msg::{WithdrawableReward, WithdrawableRewardsResponse};
+
+const DAY_IN_SECONDS: u64 = 60 * 60 * 24;
+
+#[test]
+fn four_users_same_stakes_different_multipliers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::random(&env);
+
+    let user = Address::random(&env);
+    let user2 = Address::random(&env);
+    let user3 = Address::random(&env);
+    let user4 = Address::random(&env);
+
+    let lp_token = deploy_token_contract(&env, &admin);
+    let reward_token = deploy_token_contract(&env, &admin);
+
+    let staking = deploy_staking_contract(&env, admin.clone(), &lp_token.address);
+
+    staking.create_distribution_flow(&admin, &admin, &reward_token.address);
+
+    // bond tokens for users; each user has a different amount staked
+    lp_token.mint(&user, &1000);
+    staking.bond(&user, &1000);
+    lp_token.mint(&user2, &1000);
+    staking.bond(&user2, &1000);
+    lp_token.mint(&user3, &1000);
+    staking.bond(&user3, &1000);
+    lp_token.mint(&user4, &1000);
+    staking.bond(&user4, &1000);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    // fund distribution that spans over 5 days
+    let reward_amount: u128 = 1_000_000;
+    reward_token.mint(&admin, &(reward_amount as i128));
+    staking.fund_distribution(
+        &admin,
+        &0,
+        &(DAY_IN_SECONDS * 4),
+        &reward_token.address,
+        &(reward_amount as i128),
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = DAY_IN_SECONDS;
+    });
+    staking.distribute_rewards();
+    dbg!("\n\nfirst distribution");
+    // user1 claims rewards everyday, after that increasing his multiplier to 1.005
+    assert_eq!(
+        staking.query_withdrawable_rewards(&user),
+        WithdrawableRewardsResponse {
+            rewards: vec![
+                &env,
+                WithdrawableReward {
+                    reward_address: reward_token.address.clone(),
+                    reward_amount: 62_500
+                }
+            ]
+        }
+    );
+    staking.withdraw_rewards(&user);
+    assert_eq!(reward_token.balance(&user), 62_500);
+    assert_eq!(staking.query_distributed_rewards(&reward_token.address), 250_000);
+    env.ledger().with_mut(|li| {
+        li.timestamp = DAY_IN_SECONDS + 1;
+    });
+    staking.distribute_rewards();
+    assert_eq!(
+        staking.query_withdrawable_rewards(&user),
+        WithdrawableRewardsResponse {
+            rewards: vec![
+                &env,
+                WithdrawableReward {
+                    reward_address: reward_token.address.clone(),
+                    reward_amount: 0
+                }
+            ]
+        }
+    );
+
+    // env.ledger().with_mut(|li| {
+    //     li.timestamp = DAY_IN_SECONDS * 2;
+    // });
+    // staking.distribute_rewards();
+    // dbg!("\n\nsecond distribution");
+    // // user1 claims rewards everyday, after that  at 1.01
+    // staking.withdraw_rewards(&user);
+    // // user2 claims rewards every two days, after that at 1.005
+    // staking.withdraw_rewards(&user2);
+
+    // env.ledger().with_mut(|li| {
+    //     li.timestamp = DAY_IN_SECONDS * 3;
+    // });
+    // staking.distribute_rewards();
+    // dbg!("\n\nthird distribution");
+    // // user1 claims rewards everyday, after that at 1.015
+    // staking.withdraw_rewards(&user);
+    // // user3 claims rewards at 3rd day, after that at 1.005
+    // staking.withdraw_rewards(&user3);
+
+    // env.ledger().with_mut(|li| {
+    //     li.timestamp = DAY_IN_SECONDS * 4;
+    // });
+    // dbg!("\n\nfourth distribution");
+    // staking.distribute_rewards();
+    // // user1 claims rewards everyday, after that at 1.02
+    // staking.withdraw_rewards(&user);
+    // // user2 claims rewards every second day, after that at 1.01
+    // staking.withdraw_rewards(&user2);
+
+    // env.ledger().with_mut(|li| {
+    //     li.timestamp = DAY_IN_SECONDS * 5;
+    // });
+    // dbg!("\n\nfifth distribution");
+    // staking.distribute_rewards();
+    // staking.withdraw_rewards(&user);
+    // staking.withdraw_rewards(&user2);
+    // staking.withdraw_rewards(&user3);
+    // // user 4 claims his rewards first time; his bonus multiplier is 1.005 after that withdrawal
+    // staking.withdraw_rewards(&user4);
+
+    // assert_eq!(
+    //     staking.query_withdrawable_rewards(&user),
+    //     WithdrawableRewardsResponse {
+    //         rewards: vec![
+    //             &env,
+    //             WithdrawableReward {
+    //                 reward_address: reward_token.address.clone(),
+    //                 reward_amount: 11_293
+    //             }
+    //         ]
+    //     }
+    // );
+    // assert_eq!(
+    //     staking.query_withdrawable_rewards(&user2),
+    //     WithdrawableRewardsResponse {
+    //         rewards: vec![
+    //             &env,
+    //             WithdrawableReward {
+    //                 reward_address: reward_token.address.clone(),
+    //                 reward_amount: 11_293
+    //             }
+    //         ]
+    //     }
+    // );
+    // assert_eq!(
+    //     staking.query_withdrawable_rewards(&user3),
+    //     WithdrawableRewardsResponse {
+    //         rewards: vec![
+    //             &env,
+    //             WithdrawableReward {
+    //                 reward_address: reward_token.address.clone(),
+    //                 reward_amount: 11_292
+    //             }
+    //         ]
+    //     }
+    // );
+    // assert_eq!(
+    //     staking.query_withdrawable_rewards(&user4),
+    //     WithdrawableRewardsResponse {
+    //         rewards: vec![
+    //             &env,
+    //             WithdrawableReward {
+    //                 reward_address: reward_token.address.clone(),
+    //                 reward_amount: 11_293
+    //             }
+    //         ]
+    //     }
+    // );
+    // assert_eq!(reward_token.balance(&user), 271_019);
+    // assert_eq!(staking.query_staked(&user).current_rewards_bps, 2500);
+    // assert_eq!(reward_token.balance(&user2), 248_434);
+    // assert_eq!(staking.query_staked(&user2).current_rewards_bps, 1500);
+    // assert_eq!(reward_token.balance(&user3), 237_142);
+    // assert_eq!(staking.query_staked(&user3).current_rewards_bps, 1000);
+    // assert_eq!(reward_token.balance(&user4), 225_849);
+    // assert_eq!(staking.query_staked(&user4).current_rewards_bps, 500);
+
+    // assert_eq!(staking.query_undistributed_rewards(&reward_token.address), 0);
+    // assert_eq!(staking.query_distributed_rewards(&reward_token.address), reward_amount);
+
+    // assert_eq!(reward_token.balance(&user) + reward_token.balance(&user2) + reward_token.balance(&user3) + reward_token.balance(&user4), reward_amount as i128);
+}

--- a/contracts/stake/src/tests/setup.rs
+++ b/contracts/stake/src/tests/setup.rs
@@ -12,6 +12,8 @@ pub fn deploy_token_contract<'a>(env: &Env, admin: &Address) -> token_contract::
 const MIN_BOND: i128 = 1000;
 const MAX_DISTRIBUTIONS: u32 = 7;
 const MIN_REWARD: i128 = 1000;
+const MAX_BONUS_BPS: i64 = 30_000; // 30%
+const BONUS_PER_DAY_BPS: i64 = 500; // 5%
 
 #[allow(clippy::too_many_arguments)]
 pub fn deploy_staking_contract<'a>(
@@ -22,6 +24,6 @@ pub fn deploy_staking_contract<'a>(
     let admin = admin.into().unwrap_or(Address::random(env));
     let staking = StakingClient::new(env, &env.register_contract(None, Staking {}));
 
-    staking.initialize(&admin, lp_token, &MIN_BOND, &MAX_DISTRIBUTIONS, &MIN_REWARD);
+    staking.initialize(&admin, lp_token, &MIN_BOND, &MAX_DISTRIBUTIONS, &MIN_REWARD, &BONUS_PER_DAY_BPS, &MAX_BONUS_BPS);
     staking
 }

--- a/contracts/stake/src/tests/setup.rs
+++ b/contracts/stake/src/tests/setup.rs
@@ -12,8 +12,8 @@ pub fn deploy_token_contract<'a>(env: &Env, admin: &Address) -> token_contract::
 const MIN_BOND: i128 = 1000;
 const MAX_DISTRIBUTIONS: u32 = 7;
 const MIN_REWARD: i128 = 1000;
-const MAX_BONUS_BPS: i64 = 30_000; // 30%
-const BONUS_PER_DAY_BPS: i64 = 500; // 5%
+const MAX_BONUS_BPS: i64 = 3_000; // 30%
+const BONUS_PER_DAY_BPS: i64 = 50; // 0.5%
 
 #[allow(clippy::too_many_arguments)]
 pub fn deploy_staking_contract<'a>(

--- a/contracts/stake/src/tests/setup.rs
+++ b/contracts/stake/src/tests/setup.rs
@@ -24,6 +24,14 @@ pub fn deploy_staking_contract<'a>(
     let admin = admin.into().unwrap_or(Address::random(env));
     let staking = StakingClient::new(env, &env.register_contract(None, Staking {}));
 
-    staking.initialize(&admin, lp_token, &MIN_BOND, &MAX_DISTRIBUTIONS, &MIN_REWARD, &BONUS_PER_DAY_BPS, &MAX_BONUS_BPS);
+    staking.initialize(
+        &admin,
+        lp_token,
+        &MIN_BOND,
+        &MAX_DISTRIBUTIONS,
+        &MIN_REWARD,
+        &BONUS_PER_DAY_BPS,
+        &MAX_BONUS_BPS,
+    );
     staking
 }


### PR DESCRIPTION
rewards (but no more often then 24h)
- remove bonus_per_day and max_bonus from distribution to main config; maintaining different bonuses per distribution would be impossible
- add current_rewards_bps to BondingInfo
- update rewards at the end of withdrawal rewards