### PR TITLE
Factory: remove tuple from factory query; rename query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to
 
 - Pair: Replace `sell_a` parameter in swap message with `offer_asset` address ([#141])
 - Pool: Rename `pair` to `pool` to avoid further confusion in names ([#139])
-- Factory: Replace tuple in a query `query_for_pool_by_pair_tuple` with a two separate parameters ([#144])
+- Factory: Replace tuple in a query `query_for_pool_by_pair_tuple` with a two separate parameters; rename that query to `query_for_pool_by_token_pair` ([#144])
 
 [#101]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/101
 [#133]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/133

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to
 
 - Pair: Replace `sell_a` parameter in swap message with `offer_asset` address ([#141])
 - Pool: Rename `pair` to `pool` to avoid further confusion in names ([#139])
+- Factory: Replace tuple in a query `query_for_pool_by_pair_tuple` with a two separate parameters ([#144])
 
 [#101]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/101
 [#133]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/133
 [#138]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/138
 [#141]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/141
 [#139]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/139
+[#144]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/144
 
 ## [0.6.0] - 2023-09-20
 

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -33,7 +33,7 @@ pub trait FactoryTrait {
 
     fn query_all_pools_details(env: Env) -> Result<Vec<LiquidityPoolInfo>, ContractError>;
 
-    fn query_for_pool_by_pool_tuple(
+    fn query_for_pool_by_token_pair(
         env: Env,
         token_a: Address,
         token_b: Address,
@@ -134,7 +134,7 @@ impl FactoryTrait for Factory {
         Ok(result)
     }
 
-    fn query_for_pool_by_pool_tuple(
+    fn query_for_pool_by_token_pair(
         env: Env,
         token_a: Address,
         token_b: Address,

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -35,7 +35,8 @@ pub trait FactoryTrait {
 
     fn query_for_pool_by_pool_tuple(
         env: Env,
-        tuple_pool: (Address, Address),
+        token_a: Address,
+        token_b: Address,
     ) -> Result<Address, ContractError>;
 
     fn get_admin(env: Env) -> Result<Address, ContractError>;
@@ -135,11 +136,12 @@ impl FactoryTrait for Factory {
 
     fn query_for_pool_by_pool_tuple(
         env: Env,
-        tuple_pool: (Address, Address),
+        token_a: Address,
+        token_b: Address,
     ) -> Result<Address, ContractError> {
         let pool_result: Option<Address> = env.storage().instance().get(&PairTupleKey {
-            token_a: tuple_pool.0.clone(),
-            token_b: tuple_pool.1.clone(),
+            token_a: token_a.clone(),
+            token_b: token_b.clone(),
         });
 
         if let Some(addr) = pool_result {
@@ -147,8 +149,8 @@ impl FactoryTrait for Factory {
         }
 
         let reverted_pool_resul: Option<Address> = env.storage().instance().get(&PairTupleKey {
-            token_a: tuple_pool.1.clone(),
-            token_b: tuple_pool.0.clone(),
+            token_a: token_b,
+            token_b: token_a,
         });
 
         if let Some(addr) = reverted_pool_resul {

--- a/contracts/factory/src/tests/queries.rs
+++ b/contracts/factory/src/tests/queries.rs
@@ -223,7 +223,7 @@ fn test_deploy_multiple_liquidity_pools() {
         assert!(all_pools.contains(pool));
     });
 
-    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token1, &token2);
+    let first_lp_address_by_tuple = factory.query_for_pool_by_token_pair(&token1, &token2);
     assert_eq!(first_lp_address_by_tuple, lp_contract_addr);
 }
 
@@ -370,16 +370,16 @@ fn test_queries_by_tuple() {
 
     let third_lp_contract_addr = factory.query_pools().get(2).unwrap();
 
-    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token2, &token1);
-    let second_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token3, &token4);
-    let third_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token5, &token6);
+    let first_lp_address_by_tuple = factory.query_for_pool_by_token_pair(&token2, &token1);
+    let second_lp_address_by_tuple = factory.query_for_pool_by_token_pair(&token3, &token4);
+    let third_lp_address_by_tuple = factory.query_for_pool_by_token_pair(&token5, &token6);
 
     assert_eq!(first_lp_address_by_tuple, lp_contract_addr);
     assert_eq!(second_lp_address_by_tuple, second_lp_contract_addr);
     assert_eq!(third_lp_address_by_tuple, third_lp_contract_addr);
 
     assert_eq!(
-        factory.try_query_for_pool_by_pool_tuple(&Address::random(&env), &Address::random(&env)),
+        factory.try_query_for_pool_by_token_pair(&Address::random(&env), &Address::random(&env)),
         Err(Ok(ContractError::LiquidityPoolPairNotFound))
     );
 }

--- a/contracts/factory/src/tests/queries.rs
+++ b/contracts/factory/src/tests/queries.rs
@@ -223,7 +223,7 @@ fn test_deploy_multiple_liquidity_pools() {
         assert!(all_pools.contains(pool));
     });
 
-    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&(token1, token2));
+    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token1, &token2);
     assert_eq!(first_lp_address_by_tuple, lp_contract_addr);
 }
 
@@ -370,16 +370,16 @@ fn test_queries_by_tuple() {
 
     let third_lp_contract_addr = factory.query_pools().get(2).unwrap();
 
-    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&(token2, token1));
-    let second_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&(token3, token4));
-    let third_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&(token5, token6));
+    let first_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token2, &token1);
+    let second_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token3, &token4);
+    let third_lp_address_by_tuple = factory.query_for_pool_by_pool_tuple(&token5, &token6);
 
     assert_eq!(first_lp_address_by_tuple, lp_contract_addr);
     assert_eq!(second_lp_address_by_tuple, second_lp_contract_addr);
     assert_eq!(third_lp_address_by_tuple, third_lp_contract_addr);
 
     assert_eq!(
-        factory.try_query_for_pool_by_pool_tuple(&(Address::random(&env), Address::random(&env))),
+        factory.try_query_for_pool_by_pool_tuple(&Address::random(&env), &Address::random(&env)),
         Err(Ok(ContractError::LiquidityPoolPairNotFound))
     );
 }

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -59,7 +59,7 @@ impl MultihopTrait for Multihop {
 
         operations.iter().for_each(|op| {
             let liquidity_pool_addr: Address = factory_client
-                .query_for_pool_by_pool_tuple(&op.clone().offer_asset, &op.ask_asset.clone());
+                .query_for_pool_by_token_pair(&op.clone().offer_asset, &op.ask_asset.clone());
 
             let lp_client = lp_contract::Client::new(&env, &liquidity_pool_addr);
             next_offer_amount = lp_client.swap(

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -59,7 +59,7 @@ impl MultihopTrait for Multihop {
 
         operations.iter().for_each(|op| {
             let liquidity_pool_addr: Address = factory_client
-                .query_for_pool_by_pool_tuple(&(op.clone().offer_asset, op.ask_asset.clone()));
+                .query_for_pool_by_pool_tuple(&op.clone().offer_asset, &op.ask_asset.clone());
 
             let lp_client = lp_contract::Client::new(&env, &liquidity_pool_addr);
             next_offer_amount = lp_client.swap(


### PR DESCRIPTION
Rename query `query_for_pool_by_pair_tuple` to `query_for_pool_by_token_pair`.