### PR TITLE
Disable the Referral feature

### DIFF
--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -103,7 +103,6 @@ impl MultihopTrait for Multihop {
             // } else {
             next_offer_amount = lp_client.swap(
                 &recipient,
-                &None,
                 &op.offer_asset,
                 &next_offer_amount,
                 &max_belief_price,

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{contract, contractimpl, contractmeta, vec, Address, Env, Vec};
 
-use crate::lp_contract::Referral;
+// FIXM: Disable Referral struct
+// use crate::lp_contract::Referral;
 use crate::storage::{
     get_factory, is_initialized, save_factory, set_initialized, DataKey,
     SimulateReverseSwapResponse, SimulateSwapResponse, Swap,
@@ -23,7 +24,8 @@ pub trait MultihopTrait {
     fn swap(
         env: Env,
         recipient: Address,
-        referral: Option<Referral>,
+        // FIXM: Disable Referral struct
+        // referral: Option<Referral>,
         operations: Vec<Swap>,
         max_belief_price: Option<i64>,
         max_spread_bps: Option<i64>,
@@ -63,7 +65,8 @@ impl MultihopTrait for Multihop {
     fn swap(
         env: Env,
         recipient: Address,
-        referral: Option<Referral>,
+        // FIXM: Disable Referral struct
+        // referral: Option<Referral>,
         operations: Vec<Swap>,
         max_belief_price: Option<i64>,
         max_spread_bps: Option<i64>,
@@ -87,16 +90,17 @@ impl MultihopTrait for Multihop {
                 .query_for_pool_by_token_pair(&op.clone().offer_asset, &op.ask_asset.clone());
 
             let lp_client = lp_contract::Client::new(&env, &liquidity_pool_addr);
-            if let Some(referral) = referral.clone() {
-                next_offer_amount = lp_client.swap(
-                    &recipient,
-                    &Some(referral),
-                    &op.offer_asset,
-                    &next_offer_amount,
-                    &max_belief_price,
-                    &max_spread_bps,
-                );
-            } else {
+            // FIXM: Disable Referral struct
+            // if let Some(referral) = referral.clone() {
+            //     next_offer_amount = lp_client.swap(
+            //         &recipient,
+            //         &Some(referral),
+            //         &op.offer_asset,
+            //         &next_offer_amount,
+            //         &max_belief_price,
+            //         &max_spread_bps,
+            //     );
+            // } else {
                 next_offer_amount = lp_client.swap(
                     &recipient,
                     &None,
@@ -105,7 +109,7 @@ impl MultihopTrait for Multihop {
                     &max_belief_price,
                     &max_spread_bps,
                 );
-            }
+            // }
         });
     }
 

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -101,14 +101,14 @@ impl MultihopTrait for Multihop {
             //         &max_spread_bps,
             //     );
             // } else {
-                next_offer_amount = lp_client.swap(
-                    &recipient,
-                    &None,
-                    &op.offer_asset,
-                    &next_offer_amount,
-                    &max_belief_price,
-                    &max_spread_bps,
-                );
+            next_offer_amount = lp_client.swap(
+                &recipient,
+                &None,
+                &op.offer_asset,
+                &next_offer_amount,
+                &max_belief_price,
+                &max_spread_bps,
+            );
             // }
         });
     }

--- a/contracts/multihop/src/tests/swap.rs
+++ b/contracts/multihop/src/tests/swap.rs
@@ -167,7 +167,7 @@ fn swap_three_equal_pools_no_fees_referral_fee() {
 
     let operations = vec![&env, swap1, swap2, swap3];
     let referral_addr = Address::random(&env);
-// FIXM: Disable Referral struct
+    // FIXM: Disable Referral struct
     // let referral = Referral {
     //     address: referral_addr.clone(),
     //     fee: 1_000,
@@ -181,13 +181,7 @@ fn swap_three_equal_pools_no_fees_referral_fee() {
     //     &None,
     //     &50i128,
     // );
-    multihop.swap(
-        &recipient,
-        &operations,
-        &None,
-        &None,
-        &50i128,
-    );
+    multihop.swap(&recipient, &operations, &None, &None, &50i128);
 
     // 5. check if it goes according to plan
     assert_eq!(token1.balance(&recipient), 0i128);

--- a/contracts/multihop/src/tests/swap.rs
+++ b/contracts/multihop/src/tests/swap.rs
@@ -1,4 +1,5 @@
-use crate::lp_contract::Referral;
+// FIXM: Disable Referral struct
+// use crate::lp_contract::Referral;
 use crate::storage::Swap;
 use crate::tests::setup::{
     deploy_and_initialize_factory, deploy_and_initialize_lp, deploy_and_mint_tokens,
@@ -85,13 +86,17 @@ fn swap_three_equal_pools_no_fees() {
 
     let operations = vec![&env, swap1, swap2, swap3];
 
-    multihop.swap(&recipient, &None, &operations, &None, &None, &50i128);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &operations, &None, &None, &50i128);
+    multihop.swap(&recipient, &operations, &None, &None, &50i128);
 
     // 5. check if it goes according to plan
     assert_eq!(token1.balance(&recipient), 0i128);
     assert_eq!(token4.balance(&recipient), 50i128);
 }
 
+// FIXM: Disable Referral struct
+#[ignore]
 #[test]
 fn swap_three_equal_pools_no_fees_referral_fee() {
     let env = Env::default();
@@ -162,14 +167,22 @@ fn swap_three_equal_pools_no_fees_referral_fee() {
 
     let operations = vec![&env, swap1, swap2, swap3];
     let referral_addr = Address::random(&env);
-    let referral = Referral {
-        address: referral_addr.clone(),
-        fee: 1_000,
-    };
+// FIXM: Disable Referral struct
+    // let referral = Referral {
+    //     address: referral_addr.clone(),
+    //     fee: 1_000,
+    // };
 
+    // multihop.swap(
+    //     &recipient,
+    //     &Some(referral),
+    //     &operations,
+    //     &None,
+    //     &None,
+    //     &50i128,
+    // );
     multihop.swap(
         &recipient,
-        &Some(referral),
         &operations,
         &None,
         &None,
@@ -226,7 +239,9 @@ fn swap_single_pool_no_fees() {
 
     let operations = vec![&env, swap1];
 
-    multihop.swap(&recipient, &None, &operations, &None, &None, &1_000);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, /*&None,*/ &operations, &None, &None, &50i128);
+    multihop.swap(&recipient, &operations, &None, &None, &1_000);
 
     // 5. check if it goes according to plan
     assert_eq!(token1.balance(&recipient), 4_000i128); // -1_000 token0
@@ -270,7 +285,9 @@ fn swap_should_fail_when_spread_exceeds_the_limit() {
 
     let operations = vec![&env, swap1];
 
-    multihop.swap(&recipient, &None, &operations, &None, &Some(50), &50);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &operations, &None, &Some(50), &50);
+    multihop.swap(&recipient, &operations, &None, &Some(50), &50);
 }
 
 #[test]
@@ -312,7 +329,9 @@ fn swap_single_pool_with_fees() {
 
     let operations = vec![&env, swap1];
 
-    multihop.swap(&recipient, &None, &operations, &None, &None, &300i128);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &operations, &None, &None, &300i128);
+    multihop.swap(&recipient, &operations, &None, &None, &300i128);
 
     // 5. check if it goes according to plan
     // 1000 tokens initially
@@ -393,7 +412,9 @@ fn swap_three_different_pools_no_fees() {
 
     let operations = vec![&env, swap1, swap2, swap3];
 
-    multihop.swap(&recipient, &None, &operations, &None, &None, &5_000i128);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &operations, &None, &None, &5_000i128);
+    multihop.swap(&recipient, &operations, &None, &None, &5_000i128);
 
     // 5. check if it goes according to plan
     assert_eq!(token1.balance(&recipient), 0i128);
@@ -473,7 +494,9 @@ fn swap_three_different_pools_with_fees() {
 
     let operations = vec![&env, swap1, swap2, swap3];
 
-    multihop.swap(&recipient, &None, &operations, &None, &None, &10_000i128);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &operations, &None, &None, &10_000i128);
+    multihop.swap(&recipient, &operations, &None, &None, &10_000i128);
 
     // we start swapping 10_000 tokens
 
@@ -517,5 +540,7 @@ fn swap_panics_with_no_operations() {
 
     let swap_vec = vec![&env];
 
-    multihop.swap(&recipient, &None, &swap_vec, &None, &None, &50i128);
+    // FIXM: Disable Referral struct
+    // multihop.swap(&recipient, &None, &swap_vec, &None, &None, &50i128);
+    multihop.swap(&recipient, &swap_vec, &None, &None, &50i128);
 }

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -6,7 +6,7 @@ use num_integer::Roots;
 
 use crate::contracterror::ContractError;
 use crate::storage::utils::{is_initialized, set_initialized};
-use crate::storage::{ComputeSwap, LiquidityPoolInfo, Referral};
+use crate::storage::{ComputeSwap, LiquidityPoolInfo};
 use crate::{
     stake_contract,
     storage::{
@@ -67,7 +67,8 @@ pub trait LiquidityPoolTrait {
     fn swap(
         env: Env,
         sender: Address,
-        referral: Option<Referral>,
+        // FIXM: Disable Referral struct
+        // referral: Option<Referral>,
         offer_asset: Address,
         offer_amount: i128,
         belief_price: Option<i64>,
@@ -273,7 +274,8 @@ impl LiquidityPoolTrait for LiquidityPool {
                 do_swap(
                     env.clone(),
                     sender.clone(),
-                    None,
+                    // FIXM: Disable Referral struct
+                    // None,
                     config.clone().token_a,
                     a_for_swap,
                     None,
@@ -295,7 +297,8 @@ impl LiquidityPoolTrait for LiquidityPool {
                 do_swap(
                     env.clone(),
                     sender.clone(),
-                    None,
+                    // FIXM: Disable Referral struct
+                    // None,
                     config.clone().token_b,
                     b_for_swap,
                     None,
@@ -362,7 +365,8 @@ impl LiquidityPoolTrait for LiquidityPool {
     fn swap(
         env: Env,
         sender: Address,
-        referral: Option<Referral>,
+        // FIXM: Disable Referral struct
+        // referral: Option<Referral>,
         offer_asset: Address,
         offer_amount: i128,
         belief_price: Option<i64>,
@@ -375,7 +379,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         do_swap(
             env,
             sender,
-            referral,
+            // referral,
             offer_asset,
             offer_amount,
             belief_price,
@@ -620,18 +624,20 @@ impl LiquidityPoolTrait for LiquidityPool {
 fn do_swap(
     env: Env,
     sender: Address,
-    referral: Option<Referral>,
+    // FIXM: Disable Referral struct
+    // referral: Option<Referral>,
     offer_asset: Address,
     offer_amount: i128,
     belief_price: Option<i64>,
     max_spread: Option<i64>,
 ) -> i128 {
     let config = get_config(&env);
-    if let Some(referral) = &referral {
-        if referral.fee > config.max_referral_bps {
-            panic!("Pool: Swap: Trying to swap with more than the allowed referral fee");
-        }
-    }
+    // FIXM: Disable Referral struct
+    // if let Some(referral) = &referral {
+    //     if referral.fee > config.max_referral_bps {
+    //         panic!("Pool: Swap: Trying to swap with more than the allowed referral fee");
+    //     }
+    // }
 
     let belief_price = belief_price.map(Decimal::percent);
     let max_spread = Decimal::bps(max_spread.map_or_else(|| config.max_allowed_spread_bps, |x| x));
@@ -645,10 +651,12 @@ fn do_swap(
         (pool_balance_b, pool_balance_a)
     };
 
-    let referral_fee_bps = match referral {
-        Some(ref referral) => referral.clone().fee,
-        None => 0,
-    };
+    // FIXM: Disable Referral struct
+    // let referral_fee_bps = match referral {
+    //     Some(ref referral) => referral.clone().fee,
+    //     None => 0,
+    // };
+    let referral_fee_bps = 0;
 
     // 1. We calculate the referral_fee below. If none referral fee will be 0
     let compute_swap: ComputeSwap = compute_swap(
@@ -698,15 +706,16 @@ fn do_swap(
 
     // 2. If referral is present and return amount is larger than 0 we send referral fee commision
     //    to fee recipient
-    if let Some(Referral { address, fee }) = referral {
-        if fee > 0 {
-            token_contract::Client::new(&env, &buy_token).transfer(
-                &env.current_contract_address(),
-                &address,
-                &compute_swap.referral_fee_amount,
-            );
-        }
-    }
+    // FIXM: Disable Referral struct
+    // if let Some(Referral { address, fee }) = referral {
+    //     if fee > 0 {
+    //         token_contract::Client::new(&env, &buy_token).transfer(
+    //             &env.current_contract_address(),
+    //             &address,
+    //             &compute_swap.referral_fee_amount,
+    //         );
+    //     }
+    // }
 
     // user is offering to sell A, so they will receive B
     // A balance is bigger, B balance is smaller

--- a/contracts/pool/src/tests/swap.rs
+++ b/contracts/pool/src/tests/swap.rs
@@ -6,7 +6,7 @@ use test_case::test_case;
 
 use super::setup::{deploy_liquidity_pool_contract, deploy_token_contract};
 use crate::storage::{
-    Asset, PoolResponse, Referral, SimulateReverseSwapResponse, SimulateSwapResponse,
+    Asset, PoolResponse, SimulateReverseSwapResponse, SimulateSwapResponse,
 };
 use decimal::Decimal;
 
@@ -52,7 +52,8 @@ fn simple_swap() {
     let spread = 100i64; // 1% maximum spread allowed
     pool.swap(
         &user1,
-        &None::<Referral>,
+        // FIXM: Disable Referral struct
+        // &None::<Referral>,
         &token1.address,
         &1,
         &None,
@@ -68,7 +69,8 @@ fn simple_swap() {
                     symbol_short!("swap"),
                     (
                         &user1,
-                        None::<Referral>,
+        // FIXM: Disable Referral struct
+                        // None::<Referral>,
                         token1.address.clone(),
                         1_i128,
                         None::<i64>,
@@ -115,7 +117,8 @@ fn simple_swap() {
     // this time 100 units
     let output_amount = pool.swap(
         &user1,
-        &None::<Referral>,
+        // FIXM: Disable Referral struct
+        // &None::<Referral>,
         &token2.address,
         &1_000,
         &None,
@@ -187,14 +190,15 @@ fn simple_swap_with_referral_fee() {
     // selling just one token with 1% max spread allowed
     let spread = 100i64; // 1% maximum spread allowed
                          // selling with 10% fee for the big guy
-    let referral = Referral {
-        address: referral_addr.clone(),
-        fee: 1_000,
-    };
+        // FIXM: Disable Referral struct
+    // let referral = Referral {
+    //     address: referral_addr.clone(),
+    //     fee: 1_000,
+    // };
 
     pool.swap(
         &user1,
-        &Some(referral.clone()),
+    //     &Some(referral.clone()),
         &token1.address,
         &1,
         &None,
@@ -298,16 +302,17 @@ fn test_swap_should_fail_when_referral_fee_is_larger_than_allowed() {
     );
 
     let spread = 100i64; // 1% maximum spread allowed
-    let referral = Referral {
-        address: Address::random(&env),
-        // in tests/setup.rs we hardcoded the max referral fee
-        // to 5_000 bps (50%), here we try to set it to 10_000 bps (100%)
-        fee: 10_000,
-    };
+        // FIXM: Disable Referral struct
+    // let referral = Referral {
+    //     address: Address::random(&env),
+    //     // in tests/setup.rs we hardcoded the max referral fee
+    //     // to 5_000 bps (50%), here we try to set it to 10_000 bps (100%)
+    //     fee: 10_000,
+    // };
 
     pool.swap(
         &user1,
-        &Some(referral),
+    //     &Some(referral),
         &token1.address,
         &1,
         &None,
@@ -348,9 +353,9 @@ fn swap_should_panic_with_bad_max_spread() {
     pool.provide_liquidity(&user1, &Some(5000), &None, &Some(2_000_000), &None, &None);
 
     // selling just one token with 1% max spread allowed and 50 bps max spread
+    // FIXM: Disable Referral struct
     pool.swap(
         &user1,
-        &None::<Referral>,
         &token1.address,
         &50,
         &None,

--- a/contracts/pool/src/tests/swap.rs
+++ b/contracts/pool/src/tests/swap.rs
@@ -5,9 +5,7 @@ use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, IntoVal};
 use test_case::test_case;
 
 use super::setup::{deploy_liquidity_pool_contract, deploy_token_contract};
-use crate::storage::{
-    Asset, PoolResponse, SimulateReverseSwapResponse, SimulateSwapResponse,
-};
+use crate::storage::{Asset, PoolResponse, SimulateReverseSwapResponse, SimulateSwapResponse};
 use decimal::Decimal;
 
 #[test]
@@ -69,7 +67,7 @@ fn simple_swap() {
                     symbol_short!("swap"),
                     (
                         &user1,
-        // FIXM: Disable Referral struct
+                        // FIXM: Disable Referral struct
                         // None::<Referral>,
                         token1.address.clone(),
                         1_i128,
@@ -147,6 +145,8 @@ fn simple_swap() {
     assert_eq!(token2.balance(&user1), 1001 - 1000); // user1 sold 1k of token B on second swap
 }
 
+// FIXM: Disable Referral struct
+#[ignore]
 #[test]
 fn simple_swap_with_referral_fee() {
     let env = Env::default();
@@ -190,15 +190,15 @@ fn simple_swap_with_referral_fee() {
     // selling just one token with 1% max spread allowed
     let spread = 100i64; // 1% maximum spread allowed
                          // selling with 10% fee for the big guy
-        // FIXM: Disable Referral struct
-    // let referral = Referral {
-    //     address: referral_addr.clone(),
-    //     fee: 1_000,
-    // };
+                         // FIXM: Disable Referral struct
+                         // let referral = Referral {
+                         //     address: referral_addr.clone(),
+                         //     fee: 1_000,
+                         // };
 
     pool.swap(
         &user1,
-    //     &Some(referral.clone()),
+        //     &Some(referral.clone()),
         &token1.address,
         &1,
         &None,
@@ -232,7 +232,8 @@ fn simple_swap_with_referral_fee() {
     assert_eq!(token2.balance(&user1), 1001); // 1 from the swap
     let output_amount = pool.swap(
         &user1,
-        &Some(referral),
+        // FIXM: Disable Referral struct
+        // &Some(referral),
         &token2.address,
         &1_000,
         &None,
@@ -258,10 +259,13 @@ fn simple_swap_with_referral_fee() {
     );
     assert_eq!(output_amount, 900);
     assert_eq!(token1.balance(&user1), 1899); // 999 + 1_000 as a result of swap
-    assert_eq!(token1.balance(&referral_addr), 100);
+                                              // FIXM: Disable Referral struct
+                                              // assert_eq!(token1.balance(&referral_addr), 100);
     assert_eq!(token2.balance(&user1), 1001 - 1000); // user1 sold 1k of token B on second swap
 }
 
+// FIXM: Disable Referral struct
+#[ignore]
 #[test]
 #[should_panic(expected = "Pool: Swap: Trying to swap with more than the allowed referral fee")]
 fn test_swap_should_fail_when_referral_fee_is_larger_than_allowed() {
@@ -302,17 +306,17 @@ fn test_swap_should_fail_when_referral_fee_is_larger_than_allowed() {
     );
 
     let spread = 100i64; // 1% maximum spread allowed
-        // FIXM: Disable Referral struct
-    // let referral = Referral {
-    //     address: Address::random(&env),
-    //     // in tests/setup.rs we hardcoded the max referral fee
-    //     // to 5_000 bps (50%), here we try to set it to 10_000 bps (100%)
-    //     fee: 10_000,
-    // };
+                         // FIXM: Disable Referral struct
+                         // let referral = Referral {
+                         //     address: Address::random(&env),
+                         //     // in tests/setup.rs we hardcoded the max referral fee
+                         //     // to 5_000 bps (50%), here we try to set it to 10_000 bps (100%)
+                         //     fee: 10_000,
+                         // };
 
     pool.swap(
         &user1,
-    //     &Some(referral),
+        //     &Some(referral),
         &token1.address,
         &1,
         &None,
@@ -354,13 +358,7 @@ fn swap_should_panic_with_bad_max_spread() {
 
     // selling just one token with 1% max spread allowed and 50 bps max spread
     // FIXM: Disable Referral struct
-    pool.swap(
-        &user1,
-        &token1.address,
-        &50,
-        &None,
-        &Some(50),
-    );
+    pool.swap(&user1, &token1.address, &50, &None, &Some(50));
 }
 
 #[test]
@@ -410,7 +408,8 @@ fn swap_with_high_fee() {
     // let's swap 100_000 units of Token 1 in 1:1 pool with 10% protocol fee
     pool.swap(
         &user1,
-        &None,
+        // FIXM: Disable Referral struct
+        // &None,
         &token1.address,
         &100_000,
         &None,

--- a/packages/decimal/src/lib.rs
+++ b/packages/decimal/src/lib.rs
@@ -130,15 +130,18 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// # use your_crate_name::Decimal;  // <-- Adjust to your actual crate name or module path
+    /// # use decimal::Decimal;
+    /// use soroban_sdk::{String, Env};
+    ///
+    /// let e = Env::default();
     /// let a = Decimal::from_atomics(1234, 3);
-    /// assert_eq!(a.to_string(), "1.234");
+    /// assert_eq!(a.to_string(&e), String::from_slice(&e, "1.234"));
     ///
     /// let a = Decimal::from_atomics(1234, 0);
-    /// assert_eq!(a.to_string(), "1234");
+    /// assert_eq!(a.to_string(&e), String::from_slice(&e, "1234"));
     ///
     /// let a = Decimal::from_atomics(1, 18);
-    /// assert_eq!(a.to_string(), "0.000000000000000001");
+    /// assert_eq!(a.to_string(&e), String::from_slice(&e, "0.000000000000000001"));
     /// ```
     pub fn from_atomics(atomics: i128, decimal_places: i32) -> Self {
         const TEN: i128 = 10;


### PR DESCRIPTION
Temporarily disable tbe feature which allows to send small portion of resulting transaction to a referral address as a reward.
During upgrade to latest soroban sdk version we've encountered an issue with importing struct through wasm binaries. In order to not prolong the debugging I decided to disable it for now.