### PR TITLE
Pool: Implement `panic_with_error` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to
 - Fixes documentation and naming ([#200])
 - Fixes incorrect assignment of total_fee_bps in both pool and pool stable ([235])
 - Pool: adds a missed part of return_amount argument ([#238])
+- Pool: Replace panic! with panic_with_error! to provide more contextual information ([#206])
 
 [#200]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/200
 [#235]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/235
 [#238]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/238
+[#206]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/206
 
 ## Added
 

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -245,6 +245,10 @@ impl LiquidityPoolTrait for LiquidityPool {
         // Check if custom_slippage_bps is more than max_allowed_slippage
         if let Some(custom_slippage) = custom_slippage_bps {
             if custom_slippage > config.max_allowed_slippage_bps {
+                log!(
+                    &env,
+                    "Pool: ProvideLiquidity: Custom slippage tolerance is more than max allowed slippage toleranc"
+                );
                 panic_with_error!(env, ContractError::ProvideLiquiditySlippageToleranceTooHigh);
             }
         }
@@ -315,7 +319,7 @@ impl LiquidityPoolTrait for LiquidityPool {
             _ => {
                 log!(
                     &env,
-                    "At least one token must be provided and must be bigger then 0!"
+                        "Pool: ProvideLiquidity: At least one token must be provided and must be bigger then 0!"
                 );
                 panic_with_error!(
                     env,
@@ -425,7 +429,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         if return_amount_a < min_a || return_amount_b < min_b {
             log!(
                 &env,
-                "Minimum amount of token_a or token_b is not satisfied! min_a: {}, min_b: {}, return_amount_a: {}, return_amount_b: {}",
+                "Pool: WithdrawLiquidity: Minimum amount of token_a or token_b is not satisfied! min_a: {}, min_b: {}, return_amount_a: {}, return_amount_b: {}",
                 min_a,
                 min_b,
                 return_amount_a,
@@ -788,7 +792,10 @@ fn split_deposit_based_on_pool_ratio(
 ) -> (i128, i128) {
     // Validate the inputs
     if a_pool <= 0 || b_pool <= 0 || deposit <= 0 {
-        log!(env, "Both pools and deposit must be a positive!");
+        log!(
+            env,
+            "Pool: split_deposit_based_on_pool_ratio: Both pools and deposit must be a positive!"
+        );
         panic_with_error!(
             env,
             ContractError::SplitDepositBothPoolsAndDepositMustBePositive

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -1,23 +1,25 @@
-use phoenix::utils::LiquidityPoolInitInfo;
 use soroban_sdk::{
     contract, contractimpl, contractmeta, log, panic_with_error, Address, BytesN, Env, IntoVal,
 };
 
 use num_integer::Roots;
 
-use crate::contracterror::ContractError;
-use crate::storage::utils::{is_initialized, set_initialized};
-use crate::storage::{ComputeSwap, LiquidityPoolInfo};
 use crate::{
+    error::ContractError,
     stake_contract,
     storage::{
-        get_config, save_config, utils, validate_fee_bps, Asset, Config, PairType, PoolResponse,
+        get_config, save_config, utils,
+        utils::{is_initialized, set_initialized},
+        validate_fee_bps, Asset, ComputeSwap, Config, LiquidityPoolInfo, PairType, PoolResponse,
         SimulateReverseSwapResponse, SimulateSwapResponse,
     },
     token_contract,
 };
 use decimal::Decimal;
-use phoenix::{utils::is_approx_ratio, validate_bps, validate_int_parameters};
+use phoenix::{
+    utils::{is_approx_ratio, LiquidityPoolInitInfo},
+    validate_bps, validate_int_parameters,
+};
 
 // Metadata that is added on to the WASM custom section
 contractmeta!(
@@ -243,7 +245,7 @@ impl LiquidityPoolTrait for LiquidityPool {
         // Check if custom_slippage_bps is more than max_allowed_slippage
         if let Some(custom_slippage) = custom_slippage_bps {
             if custom_slippage > config.max_allowed_slippage_bps {
-                panic!("Pool: ProvideLiquidity: Custom slippage tolerance is more than max allowed slippage tolerance");
+                panic_with_error!(env, ContractError::ProvideLiquiditySlippageToleranceTooHigh);
             }
         }
 
@@ -315,7 +317,10 @@ impl LiquidityPoolTrait for LiquidityPool {
                     &env,
                     "At least one token must be provided and must be bigger then 0!"
                 );
-                panic!("Pool: ProvideLiquidity: At least one token must be provided and must be bigger then 0!");
+                panic_with_error!(
+                    env,
+                    ContractError::ProvideLiquidityAtLeastOneTokenMustBeBiggerThenZero
+                );
             }
         };
 
@@ -426,9 +431,10 @@ impl LiquidityPoolTrait for LiquidityPool {
                 return_amount_a,
                 return_amount_b
             );
-            panic!(
-                "Pool: WithdrawLiquidity: Minimum amount of token_a or token_b is not satisfied!"
-            )
+            panic_with_error!(
+                env,
+                ContractError::WithdrawLiquidityMinimumAmountOfAOrBIsNotSatisfied
+            );
         }
 
         // burn shares
@@ -783,8 +789,9 @@ fn split_deposit_based_on_pool_ratio(
     // Validate the inputs
     if a_pool <= 0 || b_pool <= 0 || deposit <= 0 {
         log!(env, "Both pools and deposit must be a positive!");
-        panic!(
-            "Pool: split_deposit_based_on_pool_ratio: Both pools and deposit must be a positive!"
+        panic_with_error!(
+            env,
+            ContractError::SplitDepositBothPoolsAndDepositMustBePositive
         );
     }
 

--- a/contracts/pool/src/contracterror.rs
+++ b/contracts/pool/src/contracterror.rs
@@ -1,8 +1,0 @@
-use soroban_sdk::contracterror;
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum ContractError {
-    SpreadExceedsLimit = 1,
-}

--- a/contracts/pool/src/error.rs
+++ b/contracts/pool/src/error.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    SpreadExceedsLimit = 1,
+
+    ProvideLiquiditySlippageToleranceTooHigh = 2,
+    ProvideLiquidityAtLeastOneTokenMustBeBiggerThenZero = 3,
+
+    WithdrawLiquidityMinimumAmountOfAOrBIsNotSatisfied = 4,
+    SplitDepositBothPoolsAndDepositMustBePositive = 5,
+    ValidateFeeBpsTotalFeesCantBeGreaterThen100 = 6,
+
+    GetDepositAmountsMinABiggerThenDesiredA = 7,
+    GetDepositAmountsMinBBiggerThenDesiredB = 8,
+    GetDepositAmountsAmountABiggerThenDesiredA = 9,
+    GetDepositAmountsAmountALessThenMinA = 10,
+    GetDepositAmountsAmountBBiggerThenDesiredB = 11,
+    GetDepositAmountsAmountBLessThenMinB = 12,
+}

--- a/contracts/pool/src/lib.rs
+++ b/contracts/pool/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 mod contract;
-mod contracterror;
+mod error;
 mod storage;
 
 pub mod token_contract {

--- a/contracts/pool/src/storage.rs
+++ b/contracts/pool/src/storage.rs
@@ -1,9 +1,9 @@
 use soroban_sdk::{
-    contracttype, log, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, ConversionError, Env,
-    Symbol, TryFromVal, Val,
+    contracttype, log, panic_with_error, symbol_short, xdr::ToXdr, Address, Bytes, BytesN,
+    ConversionError, Env, Symbol, TryFromVal, Val,
 };
 
-use crate::token_contract;
+use crate::{error::ContractError, token_contract};
 use decimal::Decimal;
 
 #[derive(Clone, Copy)]
@@ -58,7 +58,10 @@ const MAX_TOTAL_FEE_BPS: i64 = 10_000;
 pub fn validate_fee_bps(env: &Env, total_fee_bps: i64) -> i64 {
     if total_fee_bps > MAX_TOTAL_FEE_BPS {
         log!(env, "Total fees cannot be greater than 100%");
-        panic!("Pool: Validate fee bps: total fees cannot be greater than 100%")
+        panic_with_error!(
+            env,
+            ContractError::ValidateFeeBpsTotalFeesCantBeGreaterThen100
+        );
     }
     total_fee_bps
 }
@@ -247,12 +250,12 @@ pub mod utils {
 
         if let Some(min_a) = min_a {
             if min_a > desired_a {
-                panic!("Pool: Get deposit amounts: min_a > desired_a");
+                panic_with_error!(env, ContractError::GetDepositAmountsMinABiggerThenDesiredA);
             }
         }
         if let Some(min_b) = min_b {
             if min_b > desired_b {
-                panic!("Pool: Get deposit amounts: min_b > desired_b");
+                panic_with_error!(env, ContractError::GetDepositAmountsMinABiggerThenDesiredA);
             }
         }
 
@@ -269,7 +272,10 @@ pub mod utils {
                         amount_a,
                         desired_a,
                     );
-                    panic!("Pool: Get deposit amounts: amount_a > desired_a");
+                    panic_with_error!(
+                        env,
+                        ContractError::GetDepositAmountsAmountABiggerThenDesiredA
+                    );
                 }
             };
             if let Some(min_a) = min_a {
@@ -280,7 +286,7 @@ pub mod utils {
                         amount_a,
                         min_a
                     );
-                    panic!("Pool: Get deposit amounts: amount_a < min_a");
+                    panic_with_error!(env, ContractError::GetDepositAmountsAmountALessThenMinA);
                 }
             }
             amount_a
@@ -299,7 +305,10 @@ pub mod utils {
                 amount_b,
                 desired_b,
             );
-                    panic!("Pool: Get deposit amounts: amount_b > desired_b");
+                    panic_with_error!(
+                        env,
+                        ContractError::GetDepositAmountsAmountBBiggerThenDesiredB
+                    );
                 }
             };
             if let Some(min_b) = min_b {
@@ -310,7 +319,7 @@ pub mod utils {
                 amount_b,
                 min_b
             );
-                    panic!("Pool: Get deposit amounts: amount_b < min_b");
+                    panic_with_error!(env, ContractError::GetDepositAmountsAmountBLessThenMinB);
                 }
             }
             amount_b

--- a/contracts/pool/src/storage.rs
+++ b/contracts/pool/src/storage.rs
@@ -57,7 +57,10 @@ const MAX_TOTAL_FEE_BPS: i64 = 10_000;
 /// This method is used to check fee bps.
 pub fn validate_fee_bps(env: &Env, total_fee_bps: i64) -> i64 {
     if total_fee_bps > MAX_TOTAL_FEE_BPS {
-        log!(env, "Total fees cannot be greater than 100%");
+        log!(
+            env,
+            "Pool: Validate fee bps: Total fees cannot be greater than 100%"
+        );
         panic_with_error!(
             env,
             ContractError::ValidateFeeBpsTotalFeesCantBeGreaterThen100
@@ -268,7 +271,7 @@ pub mod utils {
                 } else {
                     log!(
                         env,
-                        "Deposit amount for asset A ({}) is invalid. It exceeds the desired amount ({})",
+                        "Pool: Get deposit amounts: Deposit amount for asset A ({}) is invalid. It exceeds the desired amount ({})",
                         amount_a,
                         desired_a,
                     );
@@ -282,7 +285,7 @@ pub mod utils {
                 if amount_a < min_a {
                     log!(
                         env,
-                        "Deposit amount for asset A ({}) is invalid. It falls below the minimum requirement ({})",
+                        "Pool: Get deposit amounts: Deposit amount for asset A ({}) is invalid. It falls below the minimum requirement ({})",
                         amount_a,
                         min_a
                     );
@@ -301,7 +304,7 @@ pub mod utils {
                 } else {
                     log!(
                 env,
-                "Deposit amount for asset B ({}) is invalid. It exceeds the desired amount ({})",
+                "Pool: Get deposit amounts: Deposit amount for asset B ({}) is invalid. It exceeds the desired amount ({})",
                 amount_b,
                 desired_b,
             );
@@ -315,7 +318,7 @@ pub mod utils {
                 if amount_b < min_b {
                     log!(
                 env,
-                "Deposit amount for asset B ({}) is invalid. It falls below the minimum requirement ({})",
+                "Pool: Get deposit amounts: Deposit amount for asset B ({}) is invalid. It falls below the minimum requirement ({})",
                 amount_b,
                 min_b
             );
@@ -381,14 +384,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: amount_b < min_b")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_get_deposit_amounts_amount_b_less_than_desired() {
         let env = Env::default();
         utils::get_deposit_amounts(&env, 1000, None, 1005, Some(1001), 1, 1, Decimal::bps(100));
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: amount_b < min_b")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_get_deposit_amounts_amount_b_less_than_min_b() {
         let env = Env::default();
         utils::get_deposit_amounts(&env, 1000, None, 1005, Some(1001), 1, 1, Decimal::bps(100));
@@ -411,14 +414,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: min_a > desired_a")]
+    #[should_panic(expected = "Error(Contract, #7)")]
     fn test_get_deposit_amounts_amount_a_greater_than_desired_and_less_than_min_a() {
         let env = Env::default();
         utils::get_deposit_amounts(&env, 50, Some(100), 200, None, 100, 200, Decimal::bps(100));
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: min_b > desired_b")]
+    #[should_panic(expected = "Error(Contract, #7)")]
     fn test_get_deposit_amounts_amount_b_greater_than_desired_and_less_than_min_b() {
         let env = Env::default();
         utils::get_deposit_amounts(
@@ -434,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: min_a > desired_a")]
+    #[should_panic(expected = "Error(Contract, #7)")]
     fn test_get_deposit_amounts_amount_a_less_than_min_a() {
         let env = Env::default();
         utils::get_deposit_amounts(&env, 100, Some(200), 200, None, 100, 200, Decimal::bps(100));
@@ -459,7 +462,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: amount_a > desired_a")]
+    #[should_panic(expected = "Error(Contract, #9)")]
     fn test_get_deposit_amounts_exceeds_desired() {
         let env = Env::default();
         // The calculated deposit for asset A exceeds the desired amount and is not within 1% tolerance
@@ -467,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: amount_a < min_a")]
+    #[should_panic(expected = "Error(Contract, #10)")]
     fn test_get_deposit_amounts_below_min_a() {
         let env = Env::default();
         // The calculated deposit for asset A is below the minimum requirement
@@ -484,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Pool: Get deposit amounts: amount_b < min_b")]
+    #[should_panic(expected = "Error(Contract, #12)")]
     fn test_get_deposit_amounts_below_min_b() {
         let env = Env::default();
         // The calculated deposit for asset B is below the minimum requirement
@@ -530,7 +533,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "total fees cannot be greater than 100%")]
+    #[should_panic(expected = "Pool: Validate fee bps: Total fees cannot be greater than 100%")]
     fn test_invalidate_fee_bps() {
         let env = Env::default();
         validate_fee_bps(&env, 10_001);


### PR DESCRIPTION
Lately I've been seeing more and more errors of type `UnreachableCodeReached` (great error type by the way).
I found on discord:
> (...) more specifically panic!() automatic translates to the unreachable instruction when compiled

Now I'm trying to do a deployment with the `panic_with_error`, which supposed to at least return a error number...