### PR TITLE
pool, pool_stable, stake: replace panic! with panic_with_error!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+## Added
+- all: changes panic! to panic_with_error ([#269])
+
+[#269]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/269
+
+## Bug fixes
+
+
 ## [0.9.0] - 2024-03-12
 
 ## Changed

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -86,7 +86,7 @@ impl FactoryTrait for Factory {
 
         if whitelisted_accounts.is_empty() {
             log!(&env, "Factory: Initialize: there must be at least one whitelisted account able to create liquidity pools.");
-            panic_with_error!(&env, ContractError::WhiteListedEmpty);
+            panic_with_error!(&env, ContractError::WhiteListeEmpty);
         }
 
         set_initialized(&env);

--- a/contracts/factory/src/error.rs
+++ b/contracts/factory/src/error.rs
@@ -5,7 +5,7 @@ use soroban_sdk::contracterror;
 #[repr(u32)]
 pub enum ContractError {
     AlreadyInitialized = 1,
-    WhiteListedEmpty = 2,
+    WhiteListeEmpty = 2,
     NotAuthorized = 3,
     LiquidityPoolNotFound = 4,
     TokenABiggerThanTokenB = 5,

--- a/contracts/multihop/src/error.rs
+++ b/contracts/multihop/src/error.rs
@@ -6,5 +6,5 @@ use soroban_sdk::contracterror;
 pub enum ContractError {
     AlreadyInitialized = 1,
     OperationsEmpty = 2,
-    BadSwap = 3,
+    IncorrectAssetSwap = 3,
 }

--- a/contracts/multihop/src/utils.rs
+++ b/contracts/multihop/src/utils.rs
@@ -6,7 +6,7 @@ pub fn verify_swap(env: &Env, operations: &Vec<Swap>) {
     for (current, next) in operations.iter().zip(operations.iter().skip(1)) {
         if current.ask_asset != next.offer_asset {
             log!(&env, "Multihop: Swap: Provided bad swap order");
-            panic_with_error!(&env, ContractError::BadSwap);
+            panic_with_error!(&env, ContractError::IncorrectAssetSwap);
         }
     }
 }
@@ -15,7 +15,7 @@ pub fn verify_reverse_swap(env: &Env, operations: &Vec<Swap>) {
     for (current, next) in operations.iter().zip(operations.iter().skip(1)) {
         if current.offer_asset != next.ask_asset {
             log!(&env, "Multihop: Reverse swap: Provided bad swap order");
-            panic_with_error!(&env, ContractError::BadSwap);
+            panic_with_error!(&env, ContractError::IncorrectAssetSwap);
         }
     }
 }

--- a/contracts/pool/src/error.rs
+++ b/contracts/pool/src/error.rs
@@ -23,4 +23,8 @@ pub enum ContractError {
     DesiredAmountsBelowOrEqualZero = 14,
     MinAmountsBelowZero = 15,
     AssetNotInPool = 16,
+    AlreadyInitialized = 17,
+    TokenABiggerThanTokenB = 18,
+    InvalidBps = 19,
+    SlippageInvalid = 20,
 }

--- a/contracts/pool/src/tests/stake_deployment.rs
+++ b/contracts/pool/src/tests/stake_deployment.rs
@@ -78,7 +78,7 @@ fn confirm_stake_contract_deployment() {
 }
 
 #[test]
-#[should_panic(expected = "Liquidity Pool: Initialize: initializing contract twice is not allowed")]
+#[should_panic(expected = "Pool: Initialize: initializing contract twice is not allowed")]
 fn second_pool_deployment_should_fail() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/pool_stable/src/contract.rs
+++ b/contracts/pool_stable/src/contract.rs
@@ -655,7 +655,7 @@ fn do_swap(
             &env,
             "Pool Stable: do swap: Trying to swap wrong asset. Aborting.."
         );
-        panic_with_error!(&env, ContractError::BadSwap);
+        panic_with_error!(&env, ContractError::IncorrectAssetSwap);
     }
 
     if let Some(max_spread) = max_spread {

--- a/contracts/pool_stable/src/contract.rs
+++ b/contracts/pool_stable/src/contract.rs
@@ -142,7 +142,11 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
         share_token_symbol: String,
     ) {
         if is_initialized(&env) {
-            panic!("Pool stable: Initialize: initializing contract twice is not allowed");
+            log!(
+                &env,
+                "Pool stable: Initialize: initializing contract twice is not allowed"
+            );
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
         }
 
         let admin = lp_init_info.admin;
@@ -170,17 +174,21 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
 
         // Token order validation to make sure only one instance of a pool can exist
         if token_a >= token_b {
-            log!(&env, "Pool Stable: token_a must be less than token_b");
-            panic!(
+            log!(
+                &env,
                 "Pool Stable: Initialize: First token must be alphabetically smaller than second token"
             );
+            panic_with_error!(&env, ContractError::TokenABiggerThanTokenB);
         }
 
         save_greatest_precision(&env, &token_a, &token_b);
 
         if !(0..=10_000).contains(&swap_fee_bps) {
-            log!(&env, "Pool Stable: Fees must be between 0 and 100%");
-            panic!("Pool: Initialize: Fees must be between 0 and 100%");
+            log!(
+                &env,
+                "Pool Stable: Initialize: Fees must be between 0 and 100%"
+            );
+            panic_with_error!(&env, ContractError::InvalidBps);
         }
 
         // deploy token contract
@@ -276,6 +284,7 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
         let new_balance_a = desired_a + old_balance_a;
         let new_balance_b = desired_b + old_balance_b;
         let new_invariant = compute_d(
+            &env,
             amp as u128,
             &[
                 Decimal::from_atomics(new_balance_a, 6),
@@ -288,11 +297,16 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
             let share =
                 new_invariant.to_i128_with_precision(greatest_precision) - MINIMUM_LIQUIDITY_AMOUNT;
             if share == 0 {
-                panic!("Pool: ProvideLiquidity: Liquidity amount is too low");
+                log!(
+                    &env,
+                    "Pool Stable: ProvideLiquidity: Liquidity amount is too low"
+                );
+                panic_with_error!(&env, ContractError::LowLiquidity);
             }
             share
         } else {
             let initial_invariant = compute_d(
+                &env,
                 amp as u128,
                 &[
                     Decimal::from_atomics(old_balance_a, 6),
@@ -439,7 +453,8 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
         max_allowed_spread_bps: Option<i64>,
     ) {
         if sender != utils::get_admin(&env) {
-            panic!("Pool: UpdateConfig: Unauthorized");
+            log!(&env, "Pool Stable: UpdateConfig: Unauthorized");
+            panic_with_error!(&env, ContractError::Unauthorized);
         }
 
         let mut config = get_config(&env);
@@ -449,7 +464,8 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
         }
         if let Some(total_fee_bps) = total_fee_bps {
             if !(0..=10_000).contains(&total_fee_bps) {
-                panic!("Pool: UpdateConfig: Invalid total_fee_bps");
+                log!(&env, "Pool Stable: UpdateConfig: Invalid total_fee_bps");
+                panic_with_error!(&env, ContractError::InvalidBps);
             }
             config.total_fee_bps = total_fee_bps;
         }
@@ -635,12 +651,17 @@ fn do_swap(
     let config = get_config(&env);
 
     if offer_asset != config.token_a && offer_asset != config.token_b {
-        panic!("Trying to swap wrong asset. Aborting..")
+        log!(
+            &env,
+            "Pool Stable: do swap: Trying to swap wrong asset. Aborting.."
+        );
+        panic_with_error!(&env, ContractError::BadSwap);
     }
 
     if let Some(max_spread) = max_spread {
         if !(0..=config.max_allowed_spread_bps).contains(&max_spread) {
-            panic!("max spread is out of bounds")
+            log!(&env, "Pool Stable: do swap: max spread is out of bounds");
+            panic_with_error!(&env, ContractError::InvalidBps);
         }
     }
 
@@ -792,6 +813,7 @@ pub fn compute_swap(
     let amp = compute_current_amp(env, &amp_parameters);
 
     let new_ask_pool = calc_y(
+        env,
         amp as u128,
         Decimal::from_atomics(offer_pool + offer_amount, 6),
         &[
@@ -828,6 +850,7 @@ pub fn compute_offer_amount(
     let amp = compute_current_amp(env, &amp_parameters);
 
     let new_offer_pool = calc_y(
+        env,
         amp as u128,
         Decimal::from_atomics(ask_pool - ask_amount, 6),
         &[

--- a/contracts/pool_stable/src/error.rs
+++ b/contracts/pool_stable/src/error.rs
@@ -15,7 +15,7 @@ pub enum ContractError {
     InvalidBps = 9,
     LowLiquidity = 10,
     Unauthorized = 11,
-    BadSwap = 12,
+    IncorrectAssetSwap = 12,
     NewtonMethodFailed = 13,
     CalcYErr = 14,
 }

--- a/contracts/pool_stable/src/error.rs
+++ b/contracts/pool_stable/src/error.rs
@@ -10,4 +10,12 @@ pub enum ContractError {
     ValidateFeeBpsTotalFeesCantBeGreaterThan100 = 4,
     TotalSharesEqualZero = 5,
     AssetNotInPool = 6,
+    AlreadyInitialized = 7,
+    TokenABiggerThanTokenB = 8,
+    InvalidBps = 9,
+    LowLiquidity = 10,
+    Unauthorized = 11,
+    BadSwap = 12,
+    NewtonMethodFailed = 13,
+    CalcYErr = 14,
 }

--- a/contracts/pool_stable/src/tests/config.rs
+++ b/contracts/pool_stable/src/tests/config.rs
@@ -96,7 +96,7 @@ fn update_config() {
 }
 
 #[test]
-#[should_panic(expected = "Pool: UpdateConfig: Unauthorize")]
+#[should_panic(expected = "Pool Stable: UpdateConfig: Unauthorize")]
 fn update_config_unauthorized() {
     let env = Env::default();
     env.mock_all_auths();
@@ -192,7 +192,7 @@ fn update_config_update_admin() {
 }
 
 #[test]
-#[should_panic(expected = "Pool: UpdateConfig: Invalid total_fee_bps")]
+#[should_panic(expected = "Pool Stable: UpdateConfig: Invalid total_fee_bps")]
 fn update_config_too_high_fees() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/stake/src/error.rs
+++ b/contracts/stake/src/error.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+    InvalidMinBond = 2,
+    InvalidMinReward = 3,
+    InvalidBond = 4,
+    Unauthorized = 5,
+    MinRewardNotEnough = 6,
+    RewardsInvalid = 7,
+    StakeNotFound = 8,
+    InvalidTime = 9,
+    DistributionExists = 10,
+}

--- a/contracts/stake/src/lib.rs
+++ b/contracts/stake/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 mod contract;
 mod distribution;
+mod error;
 mod msg;
 mod storage;
 

--- a/contracts/stake/src/storage.rs
+++ b/contracts/stake/src/storage.rs
@@ -66,9 +66,11 @@ pub fn save_stakes(env: &Env, key: &Address, bonding_info: &BondingInfo) {
 }
 
 pub mod utils {
+    use crate::error::ContractError;
+
     use super::*;
 
-    use soroban_sdk::{ConversionError, TryFromVal, Val};
+    use soroban_sdk::{log, panic_with_error, ConversionError, TryFromVal, Val};
 
     #[derive(Clone, Copy)]
     #[repr(u32)]
@@ -135,7 +137,8 @@ pub mod utils {
     pub fn add_distribution(e: &Env, asset: &Address) {
         let mut distributions = get_distributions(e);
         if distributions.contains(asset) {
-            panic!("Stake: Add distribution: Distribution already added");
+            log!(&e, "Stake: Add distribution: Distribution already added");
+            panic_with_error!(&e, ContractError::DistributionExists);
         }
         distributions.push_back(asset.clone());
         e.storage()

--- a/contracts/stake/src/tests/bond.rs
+++ b/contracts/stake/src/tests/bond.rs
@@ -65,7 +65,7 @@ fn test_deploying_stake_twice_should_fail() {
 }
 
 #[test]
-#[should_panic = "Stake: Bond: Trying to stake less then minimum required"]
+#[should_panic = "Stake: Bond: Trying to stake less than minimum required"]
 fn bond_too_few() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/stake/src/tests/distribution.rs
+++ b/contracts/stake/src/tests/distribution.rs
@@ -766,9 +766,7 @@ fn calculate_apr() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Stake: create distribution flow: You are not allowed to create distribution flows."
-)]
+#[should_panic(expected = "Stake: create distribution: Non-authorized creation!")]
 fn add_distribution_should_fail_when_not_authorized() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
This PR addresses the remainder of the contracts in our DEX where we had to change to `panic_with_errro`