### PR TITLE
Pool: Replace `belief_price` with minimum expected amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to
 ## [Unreleased]
 
 ## Changed
-- Token: Update the contract to latest version from soroban-examples
-- Update soroban-sdk-rs to 20.5.0
-- CI: Update rust to 1.77.0
+
+- Token: Update the contract to latest version from soroban-examples ([#274])
+- Update soroban-sdk-rs to 20.5.0 ([#275])
+- CI: Update rust to 1.77.0 ([#275])
+- Pool: Replace belief_price swap parameter with minimum amount of tokens expected to be received ([#280])
 
 ## Added
+
 - all: changes panic! to panic_with_error ([#269])
 
 [#269]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/269
+[#275]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/275
+[#274]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/274
+[#280]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/280
 
 ## Bug fixes
 

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -96,7 +96,7 @@ impl MultihopTrait for Multihop {
                 // &referral,
                 &op.offer_asset,
                 &next_offer_amount,
-                &op.max_belief_price,
+                &op.ask_asset_min_amount,
                 &max_spread_bps,
             );
         });

--- a/contracts/multihop/src/storage.rs
+++ b/contracts/multihop/src/storage.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{contracttype, Address, Env, String, Vec};
 pub struct Swap {
     pub ask_asset: Address,
     pub offer_asset: Address,
-    pub max_belief_price: Option<i64>,
+    pub ask_asset_min_amount: Option<i128>,
 }
 
 #[derive(Clone)]

--- a/contracts/multihop/src/tests/query.rs
+++ b/contracts/multihop/src/tests/query.rs
@@ -58,7 +58,7 @@ fn simulate_swap_single_pool_no_fees() {
         Swap {
             offer_asset: token1.address.clone(),
             ask_asset: token2.address.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         },
     ];
 
@@ -166,17 +166,17 @@ fn simulate_swap_three_equal_pools_no_fees() {
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &50i128,
@@ -204,17 +204,17 @@ fn simulate_swap_three_equal_pools_no_fees() {
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &50i128,
@@ -282,7 +282,7 @@ fn simulate_swap_single_pool_with_fees() {
         Swap {
             offer_asset: token1.address.clone(),
             ask_asset: token2.address.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         },
     ];
 
@@ -391,17 +391,17 @@ fn simulate_swap_three_different_pools_no_fees() {
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &5_000i128,
@@ -431,17 +431,17 @@ fn simulate_swap_three_different_pools_no_fees() {
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &4_956i128,
@@ -547,17 +547,17 @@ fn simulate_swap_three_different_pools_with_fees() {
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &10_000i128,
@@ -609,17 +609,17 @@ fn simulate_swap_three_different_pools_with_fees() {
             Swap {
                 offer_asset: token3.address.clone(),
                 ask_asset: token4.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token2.address.clone(),
                 ask_asset: token3.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
             Swap {
                 offer_asset: token1.address.clone(),
                 ask_asset: token2.address.clone(),
-                max_belief_price: None::<i64>,
+                ask_asset_min_amount: None::<i128>,
             },
         ],
         &203_143i128,

--- a/contracts/multihop/src/tests/swap.rs
+++ b/contracts/multihop/src/tests/swap.rs
@@ -74,17 +74,17 @@ fn swap_three_equal_pools_no_fees() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap2 = Swap {
         offer_asset: token2.address.clone(),
         ask_asset: token3.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap3 = Swap {
         offer_asset: token3.address.clone(),
         ask_asset: token4.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1, swap2, swap3];
@@ -158,17 +158,17 @@ fn swap_three_equal_pools_no_fees_referral_fee() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap2 = Swap {
         offer_asset: token2.address.clone(),
         ask_asset: token3.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap3 = Swap {
         offer_asset: token3.address.clone(),
         ask_asset: token4.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1, swap2, swap3];
@@ -235,7 +235,7 @@ fn swap_single_pool_no_fees() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1];
@@ -282,7 +282,7 @@ fn swap_should_fail_when_spread_exceeds_the_limit() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1];
@@ -327,7 +327,7 @@ fn swap_single_pool_with_fees() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1];
@@ -403,17 +403,17 @@ fn swap_three_different_pools_no_fees() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap2 = Swap {
         offer_asset: token2.address.clone(),
         ask_asset: token3.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap3 = Swap {
         offer_asset: token3.address.clone(),
         ask_asset: token4.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1, swap2, swap3];
@@ -488,17 +488,17 @@ fn swap_three_different_pools_with_fees() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap2 = Swap {
         offer_asset: token2.address.clone(),
         ask_asset: token3.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
     let swap3 = Swap {
         offer_asset: token3.address.clone(),
         ask_asset: token4.address.clone(),
-        max_belief_price: None::<i64>,
+        ask_asset_min_amount: None::<i128>,
     };
 
     let operations = vec![&env, swap1, swap2, swap3];
@@ -606,17 +606,17 @@ fn test_v_phx_vul_013_add_belief_price_for_every_swap() {
     let swap1 = Swap {
         offer_asset: token1.address.clone(),
         ask_asset: token2.address.clone(),
-        max_belief_price: Some(1_050),
+        ask_asset_min_amount: Some(1_050),
     };
     let swap2 = Swap {
         offer_asset: token2.address.clone(),
         ask_asset: token3.address.clone(),
-        max_belief_price: Some(2_100),
+        ask_asset_min_amount: Some(2_100),
     };
     let swap3 = Swap {
         offer_asset: token3.address.clone(),
         ask_asset: token4.address.clone(),
-        max_belief_price: Some(3_150),
+        ask_asset_min_amount: Some(3_150),
     };
 
     let operations = vec![&env, swap1, swap2, swap3];

--- a/contracts/multihop/src/utils.rs
+++ b/contracts/multihop/src/utils.rs
@@ -39,17 +39,17 @@ mod tests {
         let swap1 = Swap {
             offer_asset: token1.clone(),
             ask_asset: token2.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap2 = Swap {
             offer_asset: token2.clone(),
             ask_asset: token3.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap3 = Swap {
             offer_asset: token3.clone(),
             ask_asset: token4.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
 
         let operations = vec![&env, swap1, swap2, swap3];
@@ -69,17 +69,17 @@ mod tests {
         let swap1 = Swap {
             offer_asset: token3.clone(),
             ask_asset: token4.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap2 = Swap {
             offer_asset: token2.clone(),
             ask_asset: token3.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap3 = Swap {
             offer_asset: token1.clone(),
             ask_asset: token2.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
 
         let operations = vec![&env, swap1, swap2, swap3];
@@ -100,12 +100,12 @@ mod tests {
         let swap1 = Swap {
             offer_asset: token1.clone(),
             ask_asset: token2.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap2 = Swap {
             offer_asset: token3.clone(),
             ask_asset: token4.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
 
         let operations = vec![&env, swap1, swap2];
@@ -126,12 +126,12 @@ mod tests {
         let swap1 = Swap {
             offer_asset: token1.clone(),
             ask_asset: token2.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
         let swap2 = Swap {
             offer_asset: token3.clone(),
             ask_asset: token4.clone(),
-            max_belief_price: None::<i64>,
+            ask_asset_min_amount: None::<i128>,
         };
 
         let operations = vec![&env, swap1, swap2];

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -70,7 +70,7 @@ pub trait LiquidityPoolTrait {
         // referral: Option<Referral>,
         offer_asset: Address,
         offer_amount: i128,
-        /// Minimum amount of the ask token user expects to receive
+        // Minimum amount of the ask token user expects to receive
         ask_asset_min_amount: Option<i128>,
         max_spread_bps: Option<i64>,
     ) -> i128;
@@ -301,7 +301,8 @@ impl LiquidityPoolTrait for LiquidityPool {
                     // None,
                     config.clone().token_a,
                     a_for_swap,
-                    None,
+                    // expected amount of ask token from swap
+                    Some(b_from_swap),
                     None,
                 );
                 // return: rest of Token A amount, simulated result of swap of portion A
@@ -324,7 +325,8 @@ impl LiquidityPoolTrait for LiquidityPool {
                     // None,
                     config.clone().token_b,
                     b_for_swap,
-                    None,
+                    // expected amount of ask token from swap
+                    Some(a_from_swap),
                     None,
                 );
                 // return: simulated result of swap of portion B, rest of Token B amount
@@ -749,7 +751,6 @@ fn do_swap(
         &env,
         ask_asset_min_amount,
         max_spread,
-        offer_amount,
         total_return_amount,
         compute_swap.spread_amount,
     );
@@ -986,7 +987,6 @@ pub fn assert_max_spread(
     env: &Env,
     ask_asset_min_amount: Option<i128>,
     max_spread: Decimal,
-    offer_amount: i128,
     return_amount: i128,
     spread_amount: i128,
 ) {
@@ -994,9 +994,9 @@ pub fn assert_max_spread(
     let total_return = return_amount + spread_amount;
 
     // Calculate the spread ratio, the fraction of the return that is due to spread
-    // If the user has specified a belief price, use it to calculate the expected return
+    // If the user has specified a minimum amount to receive, use it as the expected return
     // Otherwise, use the total return
-    let spread_ratio = if let Some(ask_asset_min_amount) = expected_return {
+    let spread_ratio = if let Some(expected_return) = ask_asset_min_amount {
         Decimal::from_ratio(spread_amount, expected_return)
     } else {
         Decimal::from_ratio(spread_amount, total_return)

--- a/contracts/pool/src/error.rs
+++ b/contracts/pool/src/error.rs
@@ -27,4 +27,6 @@ pub enum ContractError {
     TokenABiggerThanTokenB = 18,
     InvalidBps = 19,
     SlippageInvalid = 20,
+
+    SwapMinReceivedBiggerThanReturn = 21,
 }

--- a/contracts/pool_stable/src/error.rs
+++ b/contracts/pool_stable/src/error.rs
@@ -18,4 +18,5 @@ pub enum ContractError {
     IncorrectAssetSwap = 12,
     NewtonMethodFailed = 13,
     CalcYErr = 14,
+    SwapMinReceivedBiggerThanReturn = 15,
 }


### PR DESCRIPTION
This change set replaces the `belief_price` argument with the amount expected to receive in return after the swap.
Rationale: It's easier and more straightforward both implementation-wise and for the user to specify those amounts directly.