### PR TITLE
Rename `decimal` package to `soroban-decimal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Changed
+
+- decimal: Rename to `soroban-decimal` and publish in crates.io ([#299])
+
+[#299]: https://github.com/Phoenix-Protocol-Group/phoenix-contracts/pull/299
+
 ## [1.0.0] - 2024-05-08
 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,13 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "decimal"
-version = "1.0.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +723,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "phoenix"
 version = "1.0.0"
 dependencies = [
- "decimal",
+ "soroban-decimal",
  "soroban-sdk",
  "test-case",
 ]
@@ -754,10 +747,10 @@ dependencies = [
 name = "phoenix-pool"
 version = "1.0.0"
 dependencies = [
- "decimal",
  "num-integer",
  "phoenix",
  "pretty_assertions",
+ "soroban-decimal",
  "soroban-sdk",
  "test-case",
 ]
@@ -766,10 +759,10 @@ dependencies = [
 name = "phoenix-pool-stable"
 version = "1.0.0"
 dependencies = [
- "decimal",
  "num-integer",
  "phoenix",
  "pretty_assertions",
+ "soroban-decimal",
  "soroban-sdk",
 ]
 
@@ -778,9 +771,9 @@ name = "phoenix-stake"
 version = "1.0.0"
 dependencies = [
  "curve",
- "decimal",
  "phoenix",
  "pretty_assertions",
+ "soroban-decimal",
  "soroban-sdk",
 ]
 
@@ -789,8 +782,8 @@ name = "phoenix-vesting"
 version = "1.0.0"
 dependencies = [
  "curve",
- "decimal",
  "phoenix",
+ "soroban-decimal",
  "soroban-sdk",
 ]
 
@@ -1049,6 +1042,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "soroban-decimal"
+version = "1.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Phoenix-Protocol-Group/phoenix-contracts"
 
 [workspace.dependencies]
 curve = { path = "./packages/curve" }
-decimal = { path = "./packages/decimal" }
+soroban-decimal = { path = "./packages/decimal" }
 phoenix = { path = "./packages/phoenix" }
 num-integer = { version = "0.1.45", default-features = false, features = [
     "i128",

--- a/contracts/pool/Cargo.toml
+++ b/contracts/pool/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-decimal = { workspace = true }
+soroban-decimal = { workspace = true }
 phoenix = { workspace = true }
 num-integer = { workspace = true }
 soroban-sdk = { workspace = true }

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     token_contract,
 };
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 use phoenix::{
     utils::{is_approx_ratio, LiquidityPoolInitInfo},
     validate_bps, validate_int_parameters,

--- a/contracts/pool/src/storage.rs
+++ b/contracts/pool/src/storage.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
 };
 
 use crate::{error::ContractError, token_contract};
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 #[derive(Clone, Copy)]
 #[repr(u32)]

--- a/contracts/pool/src/tests/swap.rs
+++ b/contracts/pool/src/tests/swap.rs
@@ -9,7 +9,7 @@ use test_case::test_case;
 
 use super::setup::{deploy_liquidity_pool_contract, deploy_token_contract};
 use crate::storage::{Asset, PoolResponse, SimulateReverseSwapResponse, SimulateSwapResponse};
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 #[test]
 fn simple_swap() {

--- a/contracts/pool_stable/Cargo.toml
+++ b/contracts/pool_stable/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-decimal = { workspace = true }
+soroban-decimal = { workspace = true }
 phoenix = { workspace = true }
 num-integer = { workspace = true }
 soroban-sdk = { workspace = true }

--- a/contracts/pool_stable/src/contract.rs
+++ b/contracts/pool_stable/src/contract.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     token_contract,
 };
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 use phoenix::{validate_bps, validate_int_parameters};
 
 // Minimum amount of initial LP shares to mint

--- a/contracts/pool_stable/src/math.rs
+++ b/contracts/pool_stable/src/math.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{log, panic_with_error, Env};
 
 use crate::{error::ContractError, storage::AmplifierParameters};
 
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 // TODO: Those parameters will be used for updating AMP function later
 #[allow(dead_code)]

--- a/contracts/pool_stable/src/storage.rs
+++ b/contracts/pool_stable/src/storage.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
 };
 
 use crate::{error::ContractError, token_contract};
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 #[derive(Clone, Copy)]
 #[repr(u32)]

--- a/contracts/pool_stable/src/tests/liquidity.rs
+++ b/contracts/pool_stable/src/tests/liquidity.rs
@@ -14,7 +14,7 @@ use crate::{
     storage::{Asset, PoolResponse},
     token_contract,
 };
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 #[test]
 fn provide_liqudity() {

--- a/contracts/pool_stable/src/tests/swap.rs
+++ b/contracts/pool_stable/src/tests/swap.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, IntoVal};
 
 use super::setup::{deploy_stable_liquidity_pool_contract, deploy_token_contract};
 use crate::storage::{Asset, PoolResponse, SimulateReverseSwapResponse, SimulateSwapResponse};
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 #[test]
 fn simple_swap() {

--- a/contracts/stake/Cargo.toml
+++ b/contracts/stake/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-decimal = { workspace = true }
+soroban-decimal = { workspace = true }
 curve = { workspace = true }
 phoenix = { workspace = true }
 soroban-sdk = { workspace = true }

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -1,4 +1,4 @@
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 use soroban_sdk::{
     contract, contractimpl, contractmeta, log, panic_with_error, vec, Address, BytesN, Env, String,
     Vec,

--- a/contracts/stake/src/distribution.rs
+++ b/contracts/stake/src/distribution.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{contracttype, Address, Env};
 
 use curve::Curve;
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 
 use crate::{
     storage::{get_stakes, Config},

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-decimal = { workspace = true }
+soroban-decimal = { workspace = true }
 curve = { workspace = true }
 phoenix = { workspace = true }
 soroban-sdk = { workspace = true }

--- a/packages/decimal/Cargo.toml
+++ b/packages/decimal/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "decimal"
+name = "soroban-decimal"
 version = { workspace = true }
 authors = ["Jakub <jakub@moonbite.space>"]
 repository = { workspace = true }

--- a/packages/decimal/Cargo.toml
+++ b/packages/decimal/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jakub <jakub@moonbite.space>"]
 repository = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+description = "A precise decimal arithmetic package for Soroban contracts"
 
 [dependencies]
 soroban-sdk = { workspace = true, features = ["alloc"]}

--- a/packages/decimal/README.md
+++ b/packages/decimal/README.md
@@ -1,4 +1,4 @@
-# Dex Decimal
+# Soroban Decimal
 This code is taken from the [cosmwasm-std crate](https://github.com/CosmWasm/cosmwasm.), which is licensed under the Apache License 2.0
 The contract provides a `Decimal` struct for arithmetic operations, suitable for blockchain De-Fi operations, where precision is of highest importance. It ensures that calculations are accurate up to 18 decimal places.
 

--- a/packages/decimal/src/lib.rs
+++ b/packages/decimal/src/lib.rs
@@ -101,7 +101,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// use decimal::Decimal;
+    /// use soroban_decimal::Decimal;
     /// // Value with whole and fractional part
     /// let a = Decimal::percent(123);
     /// assert_eq!(a.decimal_places(), 18);
@@ -129,7 +129,7 @@ impl Decimal {
     /// ## Examples
     ///
     /// ```
-    /// use decimal::Decimal;
+    /// use soroban_decimal::Decimal;
     /// use soroban_sdk::{String, Env};
     ///
     /// let e = Env::default();

--- a/packages/phoenix/Cargo.toml
+++ b/packages/phoenix/Cargo.toml
@@ -12,7 +12,7 @@ testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-decimal = { workspace = true }
+soroban-decimal = { workspace = true }
 
 [dev_dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/packages/phoenix/src/utils.rs
+++ b/packages/phoenix/src/utils.rs
@@ -1,4 +1,4 @@
-use decimal::Decimal;
+use soroban_decimal::Decimal;
 use soroban_sdk::{contracttype, Address};
 
 // Validate if int value is bigger then 0


### PR DESCRIPTION
We want to use it in other projects as well. I decided to rename it to give it some distinction.