### PR TITLE
stable_pool: math

### DIFF
--- a/contracts/pool_stable/src/contract.rs
+++ b/contracts/pool_stable/src/contract.rs
@@ -345,8 +345,8 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
             &env,
             amp as u128,
             &[
-                scale_value(new_balance_a, token_a_decimals, DECIMAL_PRECISION),
-                scale_value(new_balance_b, token_b_decimals, DECIMAL_PRECISION),
+                scale_value(&env, new_balance_a, token_a_decimals, DECIMAL_PRECISION),
+                scale_value(&env, new_balance_b, token_b_decimals, DECIMAL_PRECISION),
             ],
         );
 
@@ -373,11 +373,13 @@ impl StableLiquidityPoolTrait for StableLiquidityPool {
                 amp as u128,
                 &[
                     scale_value(
+                        &env,
                         convert_i128_to_u128(old_balance_a),
                         token_a_decimals,
                         DECIMAL_PRECISION,
                     ),
                     scale_value(
+                        &env,
                         convert_i128_to_u128(old_balance_b),
                         token_b_decimals,
                         DECIMAL_PRECISION,
@@ -1029,13 +1031,14 @@ pub fn compute_swap(
         env,
         amp as u128,
         scale_value(
+            env,
             offer_pool + offer_amount,
             greatest_precision,
             DECIMAL_PRECISION,
         ),
         &[
-            scale_value(offer_pool, offer_pool_precision, DECIMAL_PRECISION),
-            scale_value(ask_pool, ask_pool_precision, DECIMAL_PRECISION),
+            scale_value(env, offer_pool, offer_pool_precision, DECIMAL_PRECISION),
+            scale_value(env, ask_pool, ask_pool_precision, DECIMAL_PRECISION),
         ],
         greatest_precision,
     );
@@ -1084,13 +1087,14 @@ pub fn compute_offer_amount(
         env,
         amp as u128,
         scale_value(
+            env,
             ask_pool - convert_i128_to_u128(before_commission),
             greatest_precision,
             DECIMAL_PRECISION,
         ),
         &[
-            scale_value(offer_pool, offer_pool_precision, DECIMAL_PRECISION),
-            scale_value(ask_pool, ask_pool_precision, DECIMAL_PRECISION),
+            scale_value(env, offer_pool, offer_pool_precision, DECIMAL_PRECISION),
+            scale_value(env, ask_pool, ask_pool_precision, DECIMAL_PRECISION),
         ],
         greatest_precision,
     );

--- a/contracts/pool_stable/src/math.rs
+++ b/contracts/pool_stable/src/math.rs
@@ -74,9 +74,8 @@ pub(crate) fn compute_current_amp(env: &Env, amp_params: &AmplifierParameters) -
 /// A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
 pub fn compute_d(env: &Env, amp: u128, pools: &[u128]) -> U256 {
     let leverage = U256::from_u128(env, (amp / AMP_PRECISION as u128) * N_COINS_PRECISION);
-    let amount_a_times_coins = pools[0] * N_COINS;
-    let amount_b_times_coins = pools[1] * N_COINS;
-
+    let amount_a_times_coins = U256::from_u128(env, pools[0]).mul(&U256::from_u128(env, N_COINS));
+    let amount_b_times_coins = U256::from_u128(env, pools[1]).mul(&U256::from_u128(env, N_COINS));
     let sum_x = U256::from_u128(env, pools[0] + pools[1]); // sum(x_i), a.k.a S
     let zero = U256::from_u128(env, 0u128);
     if sum_x == zero {
@@ -88,10 +87,8 @@ pub fn compute_d(env: &Env, amp: u128, pools: &[u128]) -> U256 {
 
     // Newton's method to approximate D
     for _ in 0..ITERATIONS {
-        let d_product = d.pow(3).div(&U256::from_u128(
-            env,
-            amount_a_times_coins * amount_b_times_coins,
-        ));
+        let a_times_b_product = amount_a_times_coins.mul(&amount_b_times_coins);
+        let d_product = d.pow(3).div(&a_times_b_product);
         d_previous = d.clone();
         d = calculate_step(env, &d, &leverage, &sum_x, &d_product);
         // Equality with the precision of 1e-6

--- a/contracts/pool_stable/src/math.rs
+++ b/contracts/pool_stable/src/math.rs
@@ -20,18 +20,28 @@ const DECIMAL_FRACTIONAL: u128 = 1_000_000_000_000_000_000;
 /// 1e-6
 const TOL: u128 = 1000000000000;
 
-pub fn scale_value(atomics: u128, decimal_places: u32, target_decimal_places: u32) -> u128 {
-    const TEN: u128 = 10;
+pub fn scale_value(
+    env: &Env,
+    atomics: u128,
+    decimal_places: u32,
+    target_decimal_places: u32,
+) -> u128 {
+    let ten = U256::from_u128(env, 10);
+    let atomics = U256::from_u128(env, atomics);
 
-    if decimal_places < target_decimal_places {
-        let factor = TEN.pow(target_decimal_places - decimal_places);
-        atomics
-            .checked_mul(factor)
-            .expect("Multiplication overflow")
+    let scaled_value = if decimal_places < target_decimal_places {
+        let power = target_decimal_places - decimal_places;
+        let factor = ten.pow(power);
+        atomics.mul(&factor)
     } else {
-        let factor = TEN.pow(decimal_places - target_decimal_places);
-        atomics.checked_div(factor).expect("Division overflow")
-    }
+        let power = decimal_places - target_decimal_places;
+        let factor = ten.pow(power);
+        atomics.div(&factor)
+    };
+
+    scaled_value
+        .to_u128()
+        .expect("Value doesn't fit into u128!")
 }
 
 fn abs_diff(a: &U256, b: &U256) -> U256 {
@@ -134,50 +144,106 @@ fn calculate_step(
     l_val.div(&r_val)
 }
 
-/// Compute the swap amount `y` in proportion to `x`.
+/// Compute the swap amount `y` in proportion to `x` using a partially-reordered formula.
 ///
-/// * **Solve for y**
+/// Original stable-swap equation:
+/// ```text
+/// y² + y * (sum' - (A*n^n - 1) * D / (A * n^n)) = D^(n+1) / (n^(2n) * prod' * A)
 ///
-/// y**2 + y * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
-///
-/// y**2 + b*y = c
+/// => y² + b·y = c
+/// ```
+/// We chunk up multiplications/divisions to avoid overflow when computing `d³ * amp_prec`.
 pub(crate) fn calc_y(
     env: &Env,
     amp: u128,
-    new_amount: u128,
+    new_amount_u128: u128,
     xp: &[u128],
     target_precision: u32,
 ) -> u128 {
-    let n_coins = U256::from_u128(env, N_COINS);
-    let new_amount = U256::from_u128(env, new_amount);
+    // number of coins in the pool, e.g. 2 for a two-coin stableswap.
+    let coins_count = U256::from_u128(env, N_COINS);
 
-    let d = compute_d(env, amp, xp);
-    let leverage = U256::from_u128(env, amp * DECIMAL_FRACTIONAL * N_COINS);
-    let amp_prec = U256::from_u128(env, AMP_PRECISION as u128 * DECIMAL_FRACTIONAL);
+    // convert `new_amount_u128` to U256 for big math.
+    let new_u256_amount = U256::from_u128(env, new_amount_u128);
 
-    let c = d
-        .pow(3)
-        .mul(&amp_prec)
-        .div(&new_amount.mul(&n_coins.mul(&n_coins)).mul(&leverage));
+    // compute the stableswap invariant D.
+    let invariant_d = compute_d(env, amp, xp);
 
-    let b = new_amount.add(&d.mul(&amp_prec).div(&leverage));
+    let amp_precision_factor = U256::from_u128(env, (AMP_PRECISION as u128) * DECIMAL_FRACTIONAL);
 
-    // Solve for y by approximating: y**2 + b*y = c
-    let mut y_prev;
-    let mut y = d.clone();
+    // compute "leverage" = amp * DECIMAL_FRACTIONAL * n_coins.
+    let leverage = U256::from_u128(env, amp)
+        .mul(&U256::from_u128(env, DECIMAL_FRACTIONAL))
+        .mul(&coins_count);
+
+    // ------------------------------------------------------------------
+    // Now we compute:
+    //   c = (D^3 * amp_precision_factor) / (new_amount * n_coins^2 * leverage)
+    // but we do it in multiple steps to prevent overflow.
+    // ------------------------------------------------------------------
+
+    // Step A: D²
+    let invariant_sq = invariant_d.mul(&invariant_d);
+
+    // Step B: multiply coins_count by itself => n_coins^2, then times new_u256_amount.
+    // denominator_chunk1 = n_coins^2 * new_amount
+    let coins_count_sq = coins_count.mul(&coins_count);
+    let denominator_chunk1 = coins_count_sq.mul(&new_u256_amount);
+
+    // Step C: partial factor => (D² / (n_coins^2 * new_amount))
+    let temp_factor1 = invariant_sq.div(&denominator_chunk1);
+
+    // Step D: multiply by D => (D³ / (n_coins^2 * new_amount))
+    let temp_factor2 = temp_factor1.mul(&invariant_d);
+
+    // Step E: multiply by amp_precision_factor => (D³ * amp_prec) / (n_coins^2 * new_amount)
+    let temp_factor3 = temp_factor2.mul(&amp_precision_factor);
+
+    // Step F: finally divide by leverage =>
+    //   c = (D³ * amp_prec) / (n_coins^2 * new_amount * leverage)
+    let constant_c = temp_factor3.div(&leverage);
+
+    // ------------------------------------------------------------------
+    // b = new_amount + (D * amp_precision_factor / leverage)
+    // ------------------------------------------------------------------
+    let coefficient_b = {
+        let scaled_d = invariant_d.mul(&amp_precision_factor).div(&leverage);
+        new_u256_amount.add(&scaled_d)
+    };
+
+    // ------------------------------------------------------------------
+    // Solve for y in the equation:
+    //   y² + b·y = c  ==>  y = (y² + c) / (n_coins·y + b - D)
+    // Using iteration (Newton-like).
+    // ------------------------------------------------------------------
+    let mut y_guess = invariant_d.clone();
     for _ in 0..ITERATIONS {
-        y_prev = y.clone();
-        y = (y.pow(2).add(&c)).div(&(y.mul(&n_coins).add(&b).sub(&d)));
-        if abs_diff(&y, &y_prev) <= U256::from_u128(env, TOL) {
+        let y_prev = y_guess.clone();
+
+        // Numerator = y² + c
+        let numerator = y_guess.pow(2).add(&constant_c);
+
+        // Denominator = n_coins·y + b - D
+        let denominator = coins_count
+            .mul(&y_guess)
+            .add(&coefficient_b)
+            .sub(&invariant_d);
+
+        // Next approximation for y
+        y_guess = numerator.div(&denominator);
+
+        // Check convergence
+        if abs_diff(&y_guess, &y_prev) <= U256::from_u128(env, TOL) {
+            // Scale down from DECIMAL_PRECISION to `target_precision`.
             let divisor = 10u128.pow(DECIMAL_PRECISION - target_precision);
-            return y
+            return y_guess
                 .to_u128()
-                .expect("Pool stable: calc_y: conversion to u128 failed")
+                .expect("calc_y: final y doesn't fit in u128!")
                 / divisor;
         }
     }
 
-    // Should definitely converge in 64 iterations.
-    log!(&env, "Pool Stable: calc_y: y is not converging");
-    panic_with_error!(&env, ContractError::CalcYErr);
+    // If not converged in 64 iterations, we treat that as an error.
+    log!(env, "calc_y: not converging in 64 iterations!");
+    panic_with_error!(env, ContractError::CalcYErr);
 }

--- a/contracts/pool_stable/src/tests/liquidity.rs
+++ b/contracts/pool_stable/src/tests/liquidity.rs
@@ -160,17 +160,17 @@ fn provide_liqudity_big_numbers() {
     let token_share = token_contract::Client::new(&env, &share_token_address);
 
     // minting 1_000_000 tokens to the user
-    token1.mint(&user1, &1_000_000_0000000);
-    assert_eq!(token1.balance(&user1), 1_000_000_0000000);
+    token1.mint(&user1, &10_000_000_000_000);
+    assert_eq!(token1.balance(&user1), 10_000_000_000_000);
 
-    token2.mint(&user1, &1_000_000_0000000);
-    assert_eq!(token2.balance(&user1), 1_000_000_0000000);
+    token2.mint(&user1, &10_000_000_000_000);
+    assert_eq!(token2.balance(&user1), 10_000_000_000_000);
 
     // user1 provides 100_000 tokens
     pool.provide_liquidity(
         &user1,
-        &100_000_0000000,
-        &100_000_0000000,
+        &1_000_000_000_000,
+        &1_000_000_000_000,
         &None,
         &None::<u64>,
         &None::<u128>,
@@ -186,8 +186,8 @@ fn provide_liqudity_big_numbers() {
                     Symbol::new(&env, "provide_liquidity"),
                     (
                         &user1,
-                        100_000_0000000i128,
-                        100_000_0000000i128,
+                        1_000_000_000_000_i128,
+                        1_000_000_000_000_i128,
                         None::<i64>,
                         None::<u64>,
                         None::<u128>
@@ -199,7 +199,7 @@ fn provide_liqudity_big_numbers() {
                         function: AuthorizedFunction::Contract((
                             token1.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 100_000_0000000i128).into_val(&env)
+                            (&user1, &pool.address, 1_000_000_000_000_i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },
@@ -207,7 +207,7 @@ fn provide_liqudity_big_numbers() {
                         function: AuthorizedFunction::Contract((
                             token2.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 100_000_0000000i128).into_val(&env)
+                            (&user1, &pool.address, 1_000_000_000_000_i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },

--- a/contracts/pool_stable/src/tests/liquidity.rs
+++ b/contracts/pool_stable/src/tests/liquidity.rs
@@ -24,6 +24,7 @@ fn provide_liqudity() {
 
     let mut token1 = deploy_token_contract(&env, &admin);
     let mut token2 = deploy_token_contract(&env, &admin);
+
     if token2.address < token1.address {
         std::mem::swap(&mut token1, &mut token2);
     }
@@ -45,14 +46,21 @@ fn provide_liqudity() {
     let share_token_address = pool.query_share_token_address();
     let token_share = token_contract::Client::new(&env, &share_token_address);
 
-    token1.mint(&user1, &1000);
-    assert_eq!(token1.balance(&user1), 1000);
+    token1.mint(&user1, &100000000000);
+    assert_eq!(token1.balance(&user1), 100000000000);
 
-    token2.mint(&user1, &1000);
-    assert_eq!(token2.balance(&user1), 1000);
+    token2.mint(&user1, &100000000000);
+    assert_eq!(token2.balance(&user1), 100000000000);
 
     // tokens 1 & 2 have 7 decimal digits, meaning those values are 0.0001 of token
-    pool.provide_liquidity(&user1, &1000, &1000, &None, &None::<u64>, &None::<u128>);
+    pool.provide_liquidity(
+        &user1,
+        &2000000000,
+        &2000000000,
+        &None,
+        &None::<u64>,
+        &None::<u128>,
+    );
 
     assert_eq!(
         env.auths(),
@@ -64,8 +72,8 @@ fn provide_liqudity() {
                     Symbol::new(&env, "provide_liquidity"),
                     (
                         &user1,
-                        1000i128,
-                        1000i128,
+                        2000000000i128,
+                        2000000000i128,
                         None::<i64>,
                         None::<u64>,
                         None::<u128>
@@ -77,7 +85,7 @@ fn provide_liqudity() {
                         function: AuthorizedFunction::Contract((
                             token1.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 1000_i128).into_val(&env)
+                            (&user1, &pool.address, 2000000000_i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },
@@ -85,7 +93,7 @@ fn provide_liqudity() {
                         function: AuthorizedFunction::Contract((
                             token2.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 1000_i128).into_val(&env)
+                            (&user1, &pool.address, 2000000000_i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },
@@ -94,12 +102,12 @@ fn provide_liqudity() {
         ),]
     );
 
-    assert_eq!(token_share.balance(&user1), 1000);
+    assert_eq!(token_share.balance(&user1), 3999999000);
     assert_eq!(token_share.balance(&pool.address), 0);
-    assert_eq!(token1.balance(&user1), 0);
-    assert_eq!(token1.balance(&pool.address), 1000);
-    assert_eq!(token2.balance(&user1), 0);
-    assert_eq!(token2.balance(&pool.address), 1000);
+    assert_eq!(token1.balance(&user1), 98000000000);
+    assert_eq!(token1.balance(&pool.address), 2000000000);
+    assert_eq!(token2.balance(&user1), 98000000000);
+    assert_eq!(token2.balance(&pool.address), 2000000000);
 
     let result = pool.query_pool_info();
     assert_eq!(
@@ -107,21 +115,21 @@ fn provide_liqudity() {
         PoolResponse {
             asset_a: Asset {
                 address: token1.address,
-                amount: 1000i128
+                amount: 2000000000i128
             },
             asset_b: Asset {
                 address: token2.address,
-                amount: 1000i128
+                amount: 2000000000i128
             },
             asset_lp_share: Asset {
                 address: share_token_address,
-                amount: 1000i128
+                amount: 3999999000i128
             },
             stake_address: pool.query_stake_contract_address(),
         }
     );
 
-    assert_eq!(pool.query_total_issued_lp(), 1000);
+    assert_eq!(pool.query_total_issued_lp(), 3999999000);
 }
 
 #[test]

--- a/contracts/pool_stable/src/tests/liquidity.rs
+++ b/contracts/pool_stable/src/tests/liquidity.rs
@@ -46,17 +46,131 @@ fn provide_liqudity() {
     let share_token_address = pool.query_share_token_address();
     let token_share = token_contract::Client::new(&env, &share_token_address);
 
-    token1.mint(&user1, &100000000000);
-    assert_eq!(token1.balance(&user1), 100000000000);
+    token1.mint(&user1, &1000);
+    assert_eq!(token1.balance(&user1), 1000);
 
-    token2.mint(&user1, &100000000000);
-    assert_eq!(token2.balance(&user1), 100000000000);
+    token2.mint(&user1, &1000);
+    assert_eq!(token2.balance(&user1), 1000);
 
     // tokens 1 & 2 have 7 decimal digits, meaning those values are 0.0001 of token
+    pool.provide_liquidity(&user1, &1000, &1000, &None, &None::<u64>, &None::<u128>);
+
+    assert_eq!(
+        env.auths(),
+        [(
+            user1.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    pool.address.clone(),
+                    Symbol::new(&env, "provide_liquidity"),
+                    (
+                        &user1,
+                        1000i128,
+                        1000i128,
+                        None::<i64>,
+                        None::<u64>,
+                        None::<u128>
+                    )
+                        .into_val(&env),
+                )),
+                sub_invocations: std::vec![
+                    AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            token1.address.clone(),
+                            symbol_short!("transfer"),
+                            (&user1, &pool.address, 1000_i128).into_val(&env)
+                        )),
+                        sub_invocations: std::vec![],
+                    },
+                    AuthorizedInvocation {
+                        function: AuthorizedFunction::Contract((
+                            token2.address.clone(),
+                            symbol_short!("transfer"),
+                            (&user1, &pool.address, 1000_i128).into_val(&env)
+                        )),
+                        sub_invocations: std::vec![],
+                    },
+                ],
+            }
+        ),]
+    );
+
+    assert_eq!(token_share.balance(&user1), 1000);
+    assert_eq!(token_share.balance(&pool.address), 0);
+    assert_eq!(token1.balance(&user1), 0);
+    assert_eq!(token1.balance(&pool.address), 1000);
+    assert_eq!(token2.balance(&user1), 0);
+    assert_eq!(token2.balance(&pool.address), 1000);
+
+    let result = pool.query_pool_info();
+    assert_eq!(
+        result,
+        PoolResponse {
+            asset_a: Asset {
+                address: token1.address,
+                amount: 1000i128
+            },
+            asset_b: Asset {
+                address: token2.address,
+                amount: 1000i128
+            },
+            asset_lp_share: Asset {
+                address: share_token_address,
+                amount: 1000i128
+            },
+            stake_address: pool.query_stake_contract_address(),
+        }
+    );
+
+    assert_eq!(pool.query_total_issued_lp(), 1000);
+}
+
+#[test]
+fn provide_liqudity_big_numbers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.cost_estimate().budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let manager = Address::generate(&env);
+    let factory = Address::generate(&env);
+
+    let mut token1 = deploy_token_contract(&env, &admin);
+    let mut token2 = deploy_token_contract(&env, &admin);
+
+    if token2.address < token1.address {
+        std::mem::swap(&mut token1, &mut token2);
+    }
+    let user1 = Address::generate(&env);
+    let swap_fees = 0i64;
+    let pool = deploy_stable_liquidity_pool_contract(
+        &env,
+        None,
+        (&token1.address, &token2.address),
+        swap_fees,
+        None,
+        None,
+        None,
+        manager,
+        factory,
+        None,
+    );
+
+    let share_token_address = pool.query_share_token_address();
+    let token_share = token_contract::Client::new(&env, &share_token_address);
+
+    // minting 1_000_000 tokens to the user
+    token1.mint(&user1, &1_000_000_0000000);
+    assert_eq!(token1.balance(&user1), 1_000_000_0000000);
+
+    token2.mint(&user1, &1_000_000_0000000);
+    assert_eq!(token2.balance(&user1), 1_000_000_0000000);
+
+    // user1 provides 100_000 tokens
     pool.provide_liquidity(
         &user1,
-        &2000000000,
-        &2000000000,
+        &100_000_0000000,
+        &100_000_0000000,
         &None,
         &None::<u64>,
         &None::<u128>,
@@ -72,8 +186,8 @@ fn provide_liqudity() {
                     Symbol::new(&env, "provide_liquidity"),
                     (
                         &user1,
-                        2000000000i128,
-                        2000000000i128,
+                        100_000_0000000i128,
+                        100_000_0000000i128,
                         None::<i64>,
                         None::<u64>,
                         None::<u128>
@@ -85,7 +199,7 @@ fn provide_liqudity() {
                         function: AuthorizedFunction::Contract((
                             token1.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 2000000000_i128).into_val(&env)
+                            (&user1, &pool.address, 100_000_0000000i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },
@@ -93,7 +207,7 @@ fn provide_liqudity() {
                         function: AuthorizedFunction::Contract((
                             token2.address.clone(),
                             symbol_short!("transfer"),
-                            (&user1, &pool.address, 2000000000_i128).into_val(&env)
+                            (&user1, &pool.address, 100_000_0000000i128).into_val(&env)
                         )),
                         sub_invocations: std::vec![],
                     },
@@ -102,12 +216,12 @@ fn provide_liqudity() {
         ),]
     );
 
-    assert_eq!(token_share.balance(&user1), 3999999000);
+    assert_eq!(token_share.balance(&user1), 1999999999000);
     assert_eq!(token_share.balance(&pool.address), 0);
-    assert_eq!(token1.balance(&user1), 98000000000);
-    assert_eq!(token1.balance(&pool.address), 2000000000);
-    assert_eq!(token2.balance(&user1), 98000000000);
-    assert_eq!(token2.balance(&pool.address), 2000000000);
+    assert_eq!(token1.balance(&user1), 9000000000000);
+    assert_eq!(token1.balance(&pool.address), 1000000000000);
+    assert_eq!(token2.balance(&user1), 9000000000000);
+    assert_eq!(token2.balance(&pool.address), 1000000000000);
 
     let result = pool.query_pool_info();
     assert_eq!(
@@ -115,21 +229,21 @@ fn provide_liqudity() {
         PoolResponse {
             asset_a: Asset {
                 address: token1.address,
-                amount: 2000000000i128
+                amount: 1000000000000i128
             },
             asset_b: Asset {
                 address: token2.address,
-                amount: 2000000000i128
+                amount: 1000000000000i128
             },
             asset_lp_share: Asset {
                 address: share_token_address,
-                amount: 3999999000i128
+                amount: 1999999999000i128
             },
             stake_address: pool.query_stake_contract_address(),
         }
     );
 
-    assert_eq!(pool.query_total_issued_lp(), 3999999000);
+    assert_eq!(pool.query_total_issued_lp(), 1999999999000);
 }
 
 #[test]

--- a/contracts/pool_stable/src/tests/swap.rs
+++ b/contracts/pool_stable/src/tests/swap.rs
@@ -286,6 +286,89 @@ fn simple_swap_millions_liquidity_swapping_half_milion_no_fee() {
 }
 
 #[test]
+fn simple_swap_ten_thousand_tokens() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.cost_estimate().budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let manager = Address::generate(&env);
+    let factory = Address::generate(&env);
+
+    let mut token1 = deploy_token_contract(&env, &admin);
+    let mut token2 = deploy_token_contract(&env, &admin);
+
+    if token2.address < token1.address {
+        std::mem::swap(&mut token1, &mut token2);
+    }
+    let user1 = Address::generate(&env);
+    let swap_fees = 0i64;
+    let pool = deploy_stable_liquidity_pool_contract(
+        &env,
+        None,
+        (&token1.address, &token2.address),
+        swap_fees,
+        None,
+        None,
+        None,
+        manager,
+        factory,
+        None,
+    );
+
+    // minting 100 million tokens to user1
+    token1.mint(&user1, &1_000_000_000_000_000);
+    token2.mint(&user1, &1_000_000_000_000_000);
+
+    // providing 10 million tokens as liquidity
+    pool.provide_liquidity(
+        &user1,
+        &100_000_000_000_000,
+        &100_000_000_000_000,
+        &None,
+        &None::<u64>,
+        &None::<u128>,
+    );
+
+    // selling 10,000 tokens with 5% max spread allowed
+    let spread = 500i64;
+    pool.swap(
+        &user1,
+        &token1.address,
+        &1_000_000_000, // 10_000 tokens with 7 decimal precision
+        &None,
+        &Some(spread),
+        &None::<u64>,
+        &Some(150),
+    );
+
+    let share_token_address = pool.query_share_token_address();
+    let result = pool.query_pool_info();
+
+    assert_eq!(
+        result,
+        PoolResponse {
+            asset_a: Asset {
+                address: token1.address.clone(),
+                amount: 100_001_000_000_000i128,
+            },
+            asset_b: Asset {
+                address: token2.address.clone(),
+                amount: 99_999_000_001_428_i128,
+            },
+            asset_lp_share: Asset {
+                address: share_token_address.clone(),
+                amount: 199_999_999_999_000i128,
+            },
+            stake_address: pool.query_stake_contract_address(),
+        }
+    );
+
+    assert_eq!(token1.balance(&user1), 899_999_000_000_000);
+    assert_eq!(token2.balance(&user1), 900_000_999_998_572);
+}
+
+#[test]
 fn simple_swap_millions_liquidity_swapping_half_milion_high_fee() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
- updated `scale_value`: now uses the `env` parameter and `U256` type for handling larger numbers, preventing overflow issues.  
- changed `compute_d`: refactored to use the `U256` type for precise multiplication and division.  
- changed Newton's method in `compute_d`: should be achieving the same approximation of D using an optimized approach.  
- changed `calc_y`: uses a reordered formula and iterative (Newton-like) methods for the swap amount calculations.  
- fixed overflow in `calc_y`: the complex arithmetic operations are broken into smaller, manageable steps to prevent overflow errors and products of numbers that don't fit in `U256` (eg. `200000000000000000000000^3 x 100000000000`).  
