### PR TITLE
All: adds query for the cargo pkg version

### DIFF
--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -531,6 +531,10 @@ impl Factory {
         save_stable_wasm_hash(&env, new_stable_pool_hash);
     }
 
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
+    }
+
     #[allow(dead_code)]
     //TODO: Remove after we've added the key to storage
     pub fn add_new_key_to_storage(env: Env) -> Result<(), ContractError> {

--- a/contracts/multihop/src/contract.rs
+++ b/contracts/multihop/src/contract.rs
@@ -1,6 +1,7 @@
 use phoenix::ttl::{INSTANCE_RENEWAL_THRESHOLD, INSTANCE_TARGET_TTL};
 use soroban_sdk::{
-    contract, contractimpl, contractmeta, log, panic_with_error, vec, Address, BytesN, Env, Vec,
+    contract, contractimpl, contractmeta, log, panic_with_error, vec, Address, BytesN, Env, String,
+    Vec,
 };
 
 use crate::error::ContractError;
@@ -306,6 +307,11 @@ impl Multihop {
         admin.require_auth();
 
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
     }
 
     #[allow(dead_code)]

--- a/contracts/pool/src/contract.rs
+++ b/contracts/pool/src/contract.rs
@@ -877,6 +877,11 @@ impl LiquidityPool {
     }
 
     #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
+    }
+
+    #[allow(dead_code)]
     //TODO: Remove after we've added the key to storage
     pub fn add_new_key_to_storage(env: Env) -> Result<(), ContractError> {
         env.storage().persistent().set(&XYK_POOL_KEY, &true);

--- a/contracts/pool_stable/src/contract.rs
+++ b/contracts/pool_stable/src/contract.rs
@@ -907,6 +907,11 @@ impl StableLiquidityPool {
     }
 
     #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
+    }
+
+    #[allow(dead_code)]
     //TODO: Remove after we've added the key to storage
     pub fn add_new_key_to_storage(env: Env) -> Result<(), ContractError> {
         env.storage().persistent().set(&STABLE_POOL_KEY, &true);

--- a/contracts/stake/src/contract.rs
+++ b/contracts/stake/src/contract.rs
@@ -1,7 +1,7 @@
 use phoenix::ttl::{INSTANCE_RENEWAL_THRESHOLD, INSTANCE_TARGET_TTL};
 use soroban_sdk::{
     contract, contractimpl, contractmeta, log, map, panic_with_error, vec, Address, BytesN, Env,
-    Vec,
+    String, Vec,
 };
 
 use crate::{
@@ -411,6 +411,11 @@ impl Staking {
         let admin = get_admin_old(&env);
         admin.require_auth();
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
     }
 
     #[allow(dead_code)]

--- a/contracts/trader/src/contract.rs
+++ b/contracts/trader/src/contract.rs
@@ -292,6 +292,11 @@ impl Trader {
     }
 
     #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
+    }
+
+    #[allow(dead_code)]
     //TODO: Remove after we've added the key to storage
     pub fn add_new_key_to_storage(env: Env) -> Result<(), ContractError> {
         env.storage().persistent().set(&TRADER_KEY, &true);

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -3,7 +3,8 @@ use phoenix::{
     utils::{convert_i128_to_u128, convert_u128_to_i128},
 };
 use soroban_sdk::{
-    contract, contractimpl, contractmeta, log, panic_with_error, vec, Address, BytesN, Env, Vec,
+    contract, contractimpl, contractmeta, log, panic_with_error, vec, Address, BytesN, Env, String,
+    Vec,
 };
 
 #[cfg(feature = "minter")]
@@ -543,5 +544,10 @@ impl Vesting {
     pub fn add_new_key_to_storage(env: Env) -> Result<(), ContractError> {
         env.storage().persistent().set(&VESTING_KEY, &true);
         Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn query_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
     }
 }


### PR DESCRIPTION
this implementation doesn't need a separate key in storage. We just read it from the running binaries